### PR TITLE
Fix: scan ~/.config/openstack/clouds.yaml on macOS

### DIFF
--- a/src/internal/cloud/client.go
+++ b/src/internal/cloud/client.go
@@ -26,7 +26,7 @@ type Client struct {
 
 // Connect authenticates to the given cloud and initializes service clients.
 func Connect(ctx context.Context, cloudName string) (*Client, error) {
-	ao, eo, tlsConfig, err := clouds.Parse(clouds.WithCloudName(cloudName))
+	ao, eo, tlsConfig, err := clouds.Parse(clouds.WithCloudName(cloudName), clouds.WithLocations(CloudsYamlPaths()...))
 	if err != nil {
 		return nil, fmt.Errorf("parsing cloud %q: %w", cloudName, err)
 	}
@@ -35,7 +35,7 @@ func Connect(ctx context.Context, cloudName string) (*Client, error) {
 
 // ConnectWithProject authenticates scoped to a specific project.
 func ConnectWithProject(ctx context.Context, cloudName, projectID string) (*Client, error) {
-	ao, eo, tlsConfig, err := clouds.Parse(clouds.WithCloudName(cloudName))
+	ao, eo, tlsConfig, err := clouds.Parse(clouds.WithCloudName(cloudName), clouds.WithLocations(CloudsYamlPaths()...))
 	if err != nil {
 		return nil, fmt.Errorf("parsing cloud %q: %w", cloudName, err)
 	}

--- a/src/internal/cloud/clouds.go
+++ b/src/internal/cloud/clouds.go
@@ -16,7 +16,7 @@ type cloudsFile struct {
 
 // ListCloudNames parses clouds.yaml and returns sorted cloud names.
 func ListCloudNames() ([]string, error) {
-	paths := cloudsYamlPaths()
+	paths := CloudsYamlPaths()
 
 	for _, p := range paths {
 		data, err := os.ReadFile(p)
@@ -40,7 +40,8 @@ func ListCloudNames() ([]string, error) {
 	return nil, fmt.Errorf("no clouds.yaml found (searched: %v)", paths)
 }
 
-func cloudsYamlPaths() []string {
+// CloudsYamlPaths returns the list of paths searched for clouds.yaml.
+func CloudsYamlPaths() []string {
 	var paths []string
 
 	// Current directory


### PR DESCRIPTION
## Summary
- Export `CloudsYamlPaths()` and pass it to gophercloud's `clouds.Parse()` via `clouds.WithLocations()`, ensuring `Connect()` and `ConnectWithProject()` search the same paths as `ListCloudNames()`
- Fixes the macOS issue where gophercloud uses `~/Library/Application Support` instead of `~/.config`

Closes #3

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/cloud/...` passes
- [x] Manual: place clouds.yaml in `~/.config/openstack/` and verify connection works on macOS