### PR TITLE
fix: make status bar hints brighter for readability

### DIFF
--- a/src/internal/shared/styles.go
+++ b/src/internal/shared/styles.go
@@ -63,7 +63,7 @@ var (
 				Bold(true)
 
 	StyleHelp = lipgloss.NewStyle().
-			Foreground(ColorMuted)
+			Foreground(ColorFg)
 
 	StyleModal = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).


### PR DESCRIPTION
## Summary
- Change `StyleHelp` foreground from `ColorMuted` (#586E75) to `ColorFg` (#839496) so status bar hint text is clearly readable against the dark background (#073642)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Visual check: run the TUI and confirm hint text in the status bar is brighter and readable

Closes #8