### PR TITLE
fix: handle git-describe suffixes in version comparison

### DIFF
--- a/src/internal/selfupdate/selfupdate.go
+++ b/src/internal/selfupdate/selfupdate.go
@@ -172,6 +172,10 @@ func isNewer(latest, current string) bool {
 
 func parseVersion(v string) []int {
 	v = strings.TrimPrefix(v, "v")
+	// Strip git-describe suffix (e.g. "0.3.0-7-g09160b8" → "0.3.0")
+	if idx := strings.Index(v, "-"); idx >= 0 {
+		v = v[:idx]
+	}
 	parts := strings.Split(v, ".")
 	if len(parts) != 3 {
 		return nil

--- a/src/internal/selfupdate/selfupdate_test.go
+++ b/src/internal/selfupdate/selfupdate_test.go
@@ -17,6 +17,7 @@ func TestIsNewer(t *testing.T) {
 		{"v0.0.1", "v0.1.0", false},
 		{"v1.0.0", "v1.0.0", false},
 		{"v2.0.0", "v1.99.99", true},
+		{"v0.3.1", "v0.3.0-7-g09160b8", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.latest+"_vs_"+tt.current, func(t *testing.T) {
@@ -55,6 +56,8 @@ func TestParseVersion(t *testing.T) {
 		{"v1.2.3", []int{1, 2, 3}},
 		{"0.1.0", []int{0, 1, 0}},
 		{"v0.0.0", []int{0, 0, 0}},
+		{"v0.3.0-7-g09160b8", []int{0, 3, 0}},
+		{"v1.2.3-rc1", []int{1, 2, 3}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- `parseVersion` failed to parse versions like `v0.3.0-7-g09160b8` produced by `git describe`, causing `-update` to always report "already up to date"
- Strip the git-describe suffix before parsing so the semver comparison works correctly

## Test plan
- [x] Existing `selfupdate` tests pass
- [x] New test cases added for git-describe versions (`v0.3.0-7-g09160b8`, `v1.2.3-rc1`)
- [x] New `isNewer` test case: `v0.3.1` vs `v0.3.0-7-g09160b8` correctly returns `true`