### PR TITLE
Add Homebrew tap install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Single binary. No runtime dependencies. Reads your standard `clouds.yaml`.
 
 ## Installation
 
+### Homebrew (macOS & Linux)
+
+```bash
+brew install larkly/tap/lazystack
+```
+
 ### Pre-built binaries
 
 Grab the latest release for your platform from the [releases page](https://github.com/larkly/lazystack/releases/latest).


### PR DESCRIPTION
## Summary
- Add `brew install larkly/tap/lazystack` as the first install option in the README

## Test plan
- [ ] Verify the tap install command works: `brew install larkly/tap/lazystack`