### PR TITLE
test: add tests for cloudpicker and modal UI components

### DIFF
--- a/src/internal/ui/cloudpicker/cloudpicker_test.go
+++ b/src/internal/ui/cloudpicker/cloudpicker_test.go
@@ -1,0 +1,127 @@
+package cloudpicker
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/larkly/lazystack/internal/shared"
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestNew(t *testing.T) {
+	clouds := []string{"alpha", "beta", "gamma"}
+	m := New(clouds, nil)
+
+	if len(m.clouds) != 3 {
+		t.Errorf("clouds len = %d, want 3", len(m.clouds))
+	}
+	if m.cursor != 0 {
+		t.Errorf("cursor = %d, want 0", m.cursor)
+	}
+	if m.err != nil {
+		t.Errorf("err = %v, want nil", m.err)
+	}
+}
+
+func TestNew_WithError(t *testing.T) {
+	e := errors.New("no clouds.yaml")
+	m := New(nil, e)
+
+	if m.err == nil {
+		t.Error("expected error to be stored")
+	}
+	if m.err.Error() != "no clouds.yaml" {
+		t.Errorf("err = %q, want %q", m.err.Error(), "no clouds.yaml")
+	}
+}
+
+func TestCursorDown(t *testing.T) {
+	m := New([]string{"a", "b", "c"}, nil)
+
+	// Move down twice
+	m, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
+	if m.cursor != 1 {
+		t.Errorf("cursor = %d, want 1", m.cursor)
+	}
+
+	m, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
+	if m.cursor != 2 {
+		t.Errorf("cursor = %d, want 2", m.cursor)
+	}
+
+	// Should not go past end
+	m, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
+	if m.cursor != 2 {
+		t.Errorf("cursor = %d, want 2 (clamped)", m.cursor)
+	}
+}
+
+func TestCursorUp(t *testing.T) {
+	m := New([]string{"a", "b", "c"}, nil)
+
+	// Should not go below 0
+	m, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyUp}))
+	if m.cursor != 0 {
+		t.Errorf("cursor = %d, want 0 (clamped)", m.cursor)
+	}
+
+	// Move down then up
+	m, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
+	m, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyUp}))
+	if m.cursor != 0 {
+		t.Errorf("cursor = %d, want 0", m.cursor)
+	}
+}
+
+func TestEnter_SelectsCloud(t *testing.T) {
+	m := New([]string{"prod", "staging", "dev"}, nil)
+
+	// Move to "staging" (index 1)
+	m, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
+
+	var cmd tea.Cmd
+	m, cmd = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+
+	if cmd == nil {
+		t.Fatal("expected cmd from Enter")
+	}
+	msg := cmd()
+	sel, ok := msg.(shared.CloudSelectedMsg)
+	if !ok {
+		t.Fatalf("expected CloudSelectedMsg, got %T", msg)
+	}
+	if sel.CloudName != "staging" {
+		t.Errorf("CloudName = %q, want %q", sel.CloudName, "staging")
+	}
+}
+
+func TestEnter_EmptyClouds(t *testing.T) {
+	m := New([]string{}, nil)
+
+	_, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	if cmd != nil {
+		t.Error("expected nil cmd for empty clouds list")
+	}
+}
+
+func TestQuit(t *testing.T) {
+	m := New([]string{"a"}, nil)
+
+	_, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: 'q', Text: "q"}))
+	if cmd == nil {
+		t.Fatal("expected quit cmd")
+	}
+}
+
+func TestWindowSize(t *testing.T) {
+	m := New([]string{"a"}, nil)
+
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 50})
+
+	if m.width != 120 {
+		t.Errorf("width = %d, want 120", m.width)
+	}
+	if m.height != 50 {
+		t.Errorf("height = %d, want 50", m.height)
+	}
+}

--- a/src/internal/ui/modal/confirm_test.go
+++ b/src/internal/ui/modal/confirm_test.go
@@ -1,0 +1,175 @@
+package modal
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestNewConfirm(t *testing.T) {
+	m := NewConfirm("delete", "srv-123", "my-server")
+
+	if m.Action != "delete" {
+		t.Errorf("Action = %q, want %q", m.Action, "delete")
+	}
+	if m.ServerID != "srv-123" {
+		t.Errorf("ServerID = %q, want %q", m.ServerID, "srv-123")
+	}
+	if m.Name != "my-server" {
+		t.Errorf("Name = %q, want %q", m.Name, "my-server")
+	}
+	if m.focused != 1 {
+		t.Errorf("focused = %d, want 1 (cancel by default)", m.focused)
+	}
+}
+
+func TestNewBulkConfirm(t *testing.T) {
+	servers := []ServerRef{
+		{ID: "s1", Name: "web-1"},
+		{ID: "s2", Name: "web-2"},
+		{ID: "s3", Name: "web-3"},
+	}
+	m := NewBulkConfirm("reboot", servers)
+
+	if m.Action != "reboot" {
+		t.Errorf("Action = %q, want %q", m.Action, "reboot")
+	}
+	if len(m.Servers) != 3 {
+		t.Errorf("Servers len = %d, want 3", len(m.Servers))
+	}
+	if m.Name != "3 servers" {
+		t.Errorf("Name = %q, want %q", m.Name, "3 servers")
+	}
+	if m.focused != 1 {
+		t.Errorf("focused = %d, want 1 (cancel by default)", m.focused)
+	}
+}
+
+func TestConfirmKey(t *testing.T) {
+	m := NewConfirm("delete", "srv-1", "web-1")
+
+	_, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: 'y', Text: "y"}))
+	if cmd == nil {
+		t.Fatal("expected cmd from y key")
+	}
+	msg := cmd()
+	action, ok := msg.(ConfirmAction)
+	if !ok {
+		t.Fatalf("expected ConfirmAction, got %T", msg)
+	}
+	if !action.Confirm {
+		t.Error("expected Confirm = true")
+	}
+	if action.Action != "delete" {
+		t.Errorf("Action = %q, want %q", action.Action, "delete")
+	}
+	if action.ServerID != "srv-1" {
+		t.Errorf("ServerID = %q, want %q", action.ServerID, "srv-1")
+	}
+}
+
+func TestDenyKey(t *testing.T) {
+	m := NewConfirm("delete", "srv-1", "web-1")
+
+	_, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: 'n', Text: "n"}))
+	if cmd == nil {
+		t.Fatal("expected cmd from n key")
+	}
+	msg := cmd()
+	action, ok := msg.(ConfirmAction)
+	if !ok {
+		t.Fatalf("expected ConfirmAction, got %T", msg)
+	}
+	if action.Confirm {
+		t.Error("expected Confirm = false")
+	}
+}
+
+func TestBackKey(t *testing.T) {
+	m := NewConfirm("delete", "srv-1", "web-1")
+
+	_, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEscape}))
+	if cmd == nil {
+		t.Fatal("expected cmd from esc key")
+	}
+	msg := cmd()
+	action, ok := msg.(ConfirmAction)
+	if !ok {
+		t.Fatalf("expected ConfirmAction, got %T", msg)
+	}
+	if action.Confirm {
+		t.Error("expected Confirm = false on esc")
+	}
+}
+
+func TestToggleFocus(t *testing.T) {
+	m := NewConfirm("delete", "srv-1", "web-1")
+	// starts at focused=1 (cancel)
+
+	// Tab should toggle to 0
+	m, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}))
+	if m.focused != 0 {
+		t.Errorf("focused = %d, want 0 after tab", m.focused)
+	}
+
+	// Tab again should toggle back to 1
+	m, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}))
+	if m.focused != 1 {
+		t.Errorf("focused = %d, want 1 after second tab", m.focused)
+	}
+
+	// Arrow keys should also toggle
+	m, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyLeft}))
+	if m.focused != 0 {
+		t.Errorf("focused = %d, want 0 after left arrow", m.focused)
+	}
+}
+
+func TestEnter_FocusedConfirm(t *testing.T) {
+	m := NewConfirm("delete", "srv-1", "web-1")
+	m.focused = 0
+
+	_, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	if cmd == nil {
+		t.Fatal("expected cmd from enter on confirm")
+	}
+	msg := cmd()
+	action, ok := msg.(ConfirmAction)
+	if !ok {
+		t.Fatalf("expected ConfirmAction, got %T", msg)
+	}
+	if !action.Confirm {
+		t.Error("expected Confirm = true when focused on confirm button")
+	}
+}
+
+func TestEnter_FocusedCancel(t *testing.T) {
+	m := NewConfirm("delete", "srv-1", "web-1")
+	// focused defaults to 1 (cancel)
+
+	_, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	if cmd == nil {
+		t.Fatal("expected cmd from enter on cancel")
+	}
+	msg := cmd()
+	action, ok := msg.(ConfirmAction)
+	if !ok {
+		t.Fatalf("expected ConfirmAction, got %T", msg)
+	}
+	if action.Confirm {
+		t.Error("expected Confirm = false when focused on cancel button")
+	}
+}
+
+func TestConfirm_WindowSize(t *testing.T) {
+	m := NewConfirm("delete", "srv-1", "web-1")
+
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 30})
+
+	if m.Width != 80 {
+		t.Errorf("Width = %d, want 80", m.Width)
+	}
+	if m.Height != 30 {
+		t.Errorf("Height = %d, want 30", m.Height)
+	}
+}

--- a/src/internal/ui/modal/error_test.go
+++ b/src/internal/ui/modal/error_test.go
@@ -1,0 +1,67 @@
+package modal
+
+import (
+	"errors"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestNewError(t *testing.T) {
+	m := NewError("deleting server", errors.New("connection refused"))
+
+	if m.Context != "deleting server" {
+		t.Errorf("Context = %q, want %q", m.Context, "deleting server")
+	}
+	if m.Err != "connection refused" {
+		t.Errorf("Err = %q, want %q", m.Err, "connection refused")
+	}
+}
+
+func TestEnterDismisses(t *testing.T) {
+	m := NewError("test", errors.New("fail"))
+
+	_, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	if cmd == nil {
+		t.Fatal("expected cmd from enter key")
+	}
+	msg := cmd()
+	if _, ok := msg.(ErrorDismissedMsg); !ok {
+		t.Fatalf("expected ErrorDismissedMsg, got %T", msg)
+	}
+}
+
+func TestEscDismisses(t *testing.T) {
+	m := NewError("test", errors.New("fail"))
+
+	_, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEscape}))
+	if cmd == nil {
+		t.Fatal("expected cmd from esc key")
+	}
+	msg := cmd()
+	if _, ok := msg.(ErrorDismissedMsg); !ok {
+		t.Fatalf("expected ErrorDismissedMsg, got %T", msg)
+	}
+}
+
+func TestOtherKeyIgnored(t *testing.T) {
+	m := NewError("test", errors.New("fail"))
+
+	_, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: 'x', Text: "x"}))
+	if cmd != nil {
+		t.Error("expected nil cmd for unhandled key")
+	}
+}
+
+func TestError_WindowSize(t *testing.T) {
+	m := NewError("test", errors.New("fail"))
+
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+
+	if m.Width != 100 {
+		t.Errorf("Width = %d, want 100", m.Width)
+	}
+	if m.Height != 40 {
+		t.Errorf("Height = %d, want 40", m.Height)
+	}
+}


### PR DESCRIPTION
## Summary
- Add 8 tests for `cloudpicker` (cursor navigation, cloud selection, empty list, quit, window resize)
- Add 9 tests for `confirm` modal (constructors, y/n/esc keys, focus toggling, enter on confirm vs cancel)
- Add 5 tests for `error` modal (constructor, enter/esc dismissal, unhandled key, window resize)

All tests use stdlib `testing` only, matching existing project conventions.

Closes #34

## Test plan
- [x] `go test -race -count=1 ./internal/ui/cloudpicker/ ./internal/ui/modal/` passes
- [x] Full suite `go test -race ./...` passes with no regressions