### PR TITLE
fix: show friendly error for snapshot 409 conflict

### DIFF
--- a/src/internal/compute/servers.go
+++ b/src/internal/compute/servers.go
@@ -223,6 +223,9 @@ func RevertResize(ctx context.Context, client *gophercloud.ServiceClient, id str
 func CreateSnapshot(ctx context.Context, client *gophercloud.ServiceClient, id, snapshotName string) error {
 	r := servers.CreateImage(ctx, client, id, servers.CreateImageOpts{Name: snapshotName})
 	if r.Err != nil {
+		if gophercloud.ResponseCodeIs(r.Err, 409) {
+			return fmt.Errorf("server already has a snapshot in progress")
+		}
 		return fmt.Errorf("creating snapshot of server %s: %w", id, r.Err)
 	}
 	return nil


### PR DESCRIPTION
## Summary
- Detect 409 Conflict when creating a snapshot (server already has one in progress)
- Return friendly "server already has a snapshot in progress" message instead of raw API response
- Uses `gophercloud.ResponseCodeIs()` for reliable HTTP status detection

Closes #43

## Test plan
- [ ] Trigger snapshot on a server that already has a snapshot in progress
- [ ] Verify the error modal shows a friendly message, not raw JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)