### PR TITLE
feat: add rescue/unrescue server action (ctrl+w)

### DIFF
--- a/src/internal/app/actions_server.go
+++ b/src/internal/app/actions_server.go
@@ -182,6 +182,12 @@ func (m Model) openToggleConfirm(action string) (Model, tea.Cmd) {
 				} else {
 					actualAction = "lock"
 				}
+			case "rescue/unrescue":
+				if status == "RESCUE" {
+					actualAction = "unrescue"
+				} else {
+					actualAction = "rescue"
+				}
 			}
 		}
 		refs := make([]modal.ServerRef, len(servers))
@@ -250,6 +256,12 @@ func (m Model) openToggleConfirm(action string) (Model, tea.Cmd) {
 			actualAction = "unlock"
 		} else {
 			actualAction = "lock"
+		}
+	case "rescue/unrescue":
+		if status == "RESCUE" {
+			actualAction = "unrescue"
+		} else {
+			actualAction = "rescue"
 		}
 	}
 
@@ -593,6 +605,26 @@ func (m Model) executeAction(action modal.ConfirmAction) (Model, tea.Cmd) {
 			}
 			return shared.ServerActionMsg{Action: "Unlock", Name: action.Name}
 		}
+	case "rescue":
+		return m, func() tea.Msg {
+			adminPass, err := compute.RescueServer(context.Background(), client, action.ServerID)
+			if err != nil {
+				return shared.ServerActionErrMsg{Action: "Rescue", Name: action.Name, Err: err}
+			}
+			msg := shared.ServerActionMsg{Action: "Rescue", Name: action.Name}
+			if adminPass != "" {
+				msg.Action = fmt.Sprintf("Rescue (password: %s)", adminPass)
+			}
+			return msg
+		}
+	case "unrescue":
+		return m, func() tea.Msg {
+			err := compute.UnrescueServer(context.Background(), client, action.ServerID)
+			if err != nil {
+				return shared.ServerActionErrMsg{Action: "Unrescue", Name: action.Name, Err: err}
+			}
+			return shared.ServerActionMsg{Action: "Unrescue", Name: action.Name}
+		}
 	case "delete_volume":
 		bsClient := m.client.BlockStorage
 		id := action.ServerID
@@ -785,6 +817,10 @@ func (m Model) executeBulkAction(client *gophercloud.ServiceClient, action modal
 				err = compute.LockServer(context.Background(), client, s.ID)
 			case "unlock":
 				err = compute.UnlockServer(context.Background(), client, s.ID)
+			case "rescue":
+				_, err = compute.RescueServer(context.Background(), client, s.ID)
+			case "unrescue":
+				err = compute.UnrescueServer(context.Background(), client, s.ID)
 			}
 			if err != nil {
 				errs = append(errs, fmt.Sprintf("%s: %v", s.Name, err))

--- a/src/internal/app/app.go
+++ b/src/internal/app/app.go
@@ -494,6 +494,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if key.Matches(msg, shared.Keys.Lock) {
 				return m.openToggleConfirm("lock/unlock")
 			}
+			if key.Matches(msg, shared.Keys.Rescue) {
+				return m.openToggleConfirm("rescue/unrescue")
+			}
 			if key.Matches(msg, shared.Keys.Console) {
 				return m.openConsoleLog()
 			}

--- a/src/internal/compute/servers.go
+++ b/src/internal/compute/servers.go
@@ -240,6 +240,25 @@ func RebuildServer(ctx context.Context, client *gophercloud.ServiceClient, id, i
 	return nil
 }
 
+// RescueServer places a server into RESCUE mode and returns the admin password.
+func RescueServer(ctx context.Context, client *gophercloud.ServiceClient, id string) (string, error) {
+	r := servers.Rescue(ctx, client, id, servers.RescueOpts{})
+	adminPass, err := r.Extract()
+	if err != nil {
+		return "", fmt.Errorf("rescuing server %s: %w", id, err)
+	}
+	return adminPass, nil
+}
+
+// UnrescueServer returns a server from RESCUE mode.
+func UnrescueServer(ctx context.Context, client *gophercloud.ServiceClient, id string) error {
+	r := servers.Unrescue(ctx, client, id)
+	if r.Err != nil {
+		return fmt.Errorf("unrescuing server %s: %w", id, r.Err)
+	}
+	return nil
+}
+
 // RenameServer updates a server's name.
 func RenameServer(ctx context.Context, client *gophercloud.ServiceClient, id, newName string) error {
 	_, err := servers.Update(ctx, client, id, servers.UpdateOpts{Name: newName}).Extract()

--- a/src/internal/shared/keys.go
+++ b/src/internal/shared/keys.go
@@ -47,6 +47,7 @@ type KeyMap struct {
 	Rebuild     key.Binding
 	Snapshot    key.Binding
 	Deactivate  key.Binding
+	Rescue      key.Binding
 }
 
 var Keys = KeyMap{
@@ -225,5 +226,9 @@ var Keys = KeyMap{
 	Deactivate: key.NewBinding(
 		key.WithKeys("d"),
 		key.WithHelp("d", "deactivate/reactivate"),
+	),
+	Rescue: key.NewBinding(
+		key.WithKeys("ctrl+w"),
+		key.WithHelp("ctrl+w", "rescue/unrescue"),
 	),
 }


### PR DESCRIPTION
## Summary
- Add rescue/unrescue toggle action bound to `ctrl+w`
- Rescue boots server from recovery image, returns admin password in status message
- Supports both single server and bulk selection
- Follows existing toggle pattern (pause/unpause, shelve/unshelve)

Closes #25

## Test plan
- [ ] Select a server and press `ctrl+w` to rescue it
- [ ] Verify admin password is shown in the status message
- [ ] Press `ctrl+w` again on a RESCUE server to unrescue
- [ ] Test bulk rescue/unrescue with multi-select

