### PR TITLE
feat: add deb, rpm, and arch packaging to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,69 @@ jobs:
           name: lazystack-${{ matrix.goos }}-${{ matrix.goarch }}
           path: lazystack-${{ matrix.goos }}-${{ matrix.goarch }}
 
-  release:
+  package:
     needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goarch: amd64
+            deb_arch: amd64
+            rpm_arch: x86_64
+          - goarch: arm64
+            deb_arch: arm64
+            rpm_arch: aarch64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.VERSION }}
+
+      - name: Download linux binary
+        uses: actions/download-artifact@v4
+        with:
+          name: lazystack-linux-${{ matrix.goarch }}
+
+      - name: Prepare binary
+        run: |
+          chmod +x lazystack-linux-${{ matrix.goarch }}
+          cp lazystack-linux-${{ matrix.goarch }} lazystack
+
+      - name: Install nFPM
+        run: |
+          echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' \
+            | sudo tee /etc/apt/sources.list.d/goreleaser.list
+          sudo apt-get update
+          sudo apt-get install -y nfpm
+
+      - name: Build deb
+        run: |
+          export VERSION="${VERSION#v}"
+          export NFPM_ARCH="${{ matrix.deb_arch }}"
+          nfpm package --packager deb --target "lazystack_${VERSION}_${{ matrix.deb_arch }}.deb"
+
+      - name: Build rpm
+        run: |
+          export VERSION="${VERSION#v}"
+          export NFPM_ARCH="${{ matrix.rpm_arch }}"
+          nfpm package --packager rpm --target "lazystack-${VERSION}-1.${{ matrix.rpm_arch }}.rpm"
+
+      - name: Build Arch package
+        run: |
+          export VERSION="${VERSION#v}"
+          export NFPM_ARCH="${{ matrix.rpm_arch }}"
+          nfpm package --packager archlinux --target "lazystack-${VERSION}-1-${{ matrix.rpm_arch }}.pkg.tar.zst"
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages-${{ matrix.goarch }}
+          path: |
+            *.deb
+            *.rpm
+            *.pkg.tar.zst
+
+  release:
+    needs: [build, package]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -62,7 +123,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate checksums
-        run: sha256sum lazystack-* > SHA256SUMS
+        run: sha256sum lazystack-* *.deb *.rpm *.pkg.tar.zst > SHA256SUMS
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -71,6 +132,9 @@ jobs:
           generate_release_notes: true
           files: |
             lazystack-*
+            *.deb
+            *.rpm
+            *.pkg.tar.zst
             SHA256SUMS
 
       - name: Parse checksums
@@ -80,6 +144,12 @@ jobs:
           echo "darwin_amd64=$(grep darwin-amd64 SHA256SUMS | awk '{print $1}')" >> "$GITHUB_OUTPUT"
           echo "linux_arm64=$(grep linux-arm64 SHA256SUMS | awk '{print $1}')" >> "$GITHUB_OUTPUT"
           echo "linux_amd64=$(grep linux-amd64 SHA256SUMS | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
+      - name: Compute source tarball checksum
+        id: src_sha
+        run: |
+          curl -sL "https://github.com/larkly/lazystack/archive/refs/tags/${{ env.VERSION }}.tar.gz" -o source.tar.gz
+          echo "source=$(sha256sum source.tar.gz | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
       - name: Update Homebrew tap
         uses: peter-evans/repository-dispatch@v3
@@ -94,4 +164,16 @@ jobs:
               "sha256_darwin_amd64": "${{ steps.shas.outputs.darwin_amd64 }}",
               "sha256_linux_arm64": "${{ steps.shas.outputs.linux_arm64 }}",
               "sha256_linux_amd64": "${{ steps.shas.outputs.linux_amd64 }}"
+            }
+
+      - name: Update AUR package
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.AUR_REPO_TOKEN }}
+          repository: larkly/aur-lazystack
+          event-type: update-pkgbuild
+          client-payload: |
+            {
+              "version": "${{ env.VERSION }}",
+              "sha256_source": "${{ steps.src_sha.outputs.source }}"
             }

--- a/README.md
+++ b/README.md
@@ -52,6 +52,28 @@ Single binary. No runtime dependencies. Reads your standard `clouds.yaml`.
 brew install larkly/tap/lazystack
 ```
 
+### Arch Linux (AUR)
+
+```bash
+yay -S lazystack
+```
+
+### Debian / Ubuntu
+
+Download the `.deb` from the [releases page](https://github.com/larkly/lazystack/releases/latest) and install:
+
+```bash
+sudo dpkg -i lazystack_*.deb
+```
+
+### Fedora / RHEL
+
+Download the `.rpm` from the [releases page](https://github.com/larkly/lazystack/releases/latest) and install:
+
+```bash
+sudo rpm -i lazystack-*.rpm
+```
+
 ### Pre-built binaries
 
 Grab the latest release for your platform from the [releases page](https://github.com/larkly/lazystack/releases/latest).

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: larkly
+pkgname=lazystack
+pkgver=0.4.0
+pkgrel=1
+pkgdesc="A keyboard-driven terminal UI for OpenStack"
+arch=('x86_64' 'aarch64')
+url="https://github.com/larkly/lazystack"
+license=('Apache-2.0')
+makedepends=('go')
+source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('SKIP')
+
+build() {
+    cd "${pkgname}-${pkgver}/src"
+    export CGO_ENABLED=0
+    go build -ldflags "-s -w -X main.version=v${pkgver}" -o "${pkgname}" ./cmd/lazystack
+}
+
+package() {
+    cd "${pkgname}-${pkgver}/src"
+    install -Dm755 "${pkgname}" "${pkgdir}/usr/bin/${pkgname}"
+}

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,0 +1,18 @@
+name: lazystack
+arch: ${NFPM_ARCH}
+platform: linux
+version: ${VERSION}
+release: "1"
+section: utils
+priority: optional
+maintainer: larkly
+description: A keyboard-driven terminal UI for OpenStack
+vendor: larkly
+homepage: https://github.com/larkly/lazystack
+license: Apache-2.0
+
+contents:
+  - src: lazystack
+    dst: /usr/bin/lazystack
+    file_info:
+      mode: 0755


### PR DESCRIPTION
## Summary

- Add nFPM-based packaging (deb, rpm, Arch pkg.tar.zst) for amd64 and arm64 to the release workflow
- New `package` CI job runs after `build`, produces 6 package files per release
- Updated `release` job includes packages in GitHub Release artifacts and SHA256SUMS
- Automated AUR source package dispatch (mirrors existing Homebrew tap pattern)
- AUR repo created at `larkly/aur-lazystack` with PKGBUILD and update workflow

## New release artifacts

| Format | amd64 | arm64 |
|--------|-------|-------|
| .deb | `lazystack_X.Y.Z_amd64.deb` | `lazystack_X.Y.Z_arm64.deb` |
| .rpm | `lazystack-X.Y.Z-1.x86_64.rpm` | `lazystack-X.Y.Z-1.aarch64.rpm` |
| .pkg.tar.zst | `lazystack-X.Y.Z-1-x86_64.pkg.tar.zst` | `lazystack-X.Y.Z-1-aarch64.pkg.tar.zst` |

## Secrets required

- `AUR_REPO_TOKEN` — fine-grained PAT scoped to `larkly/aur-lazystack` (Contents read/write)
- `AUR_SSH_KEY` — SSH key for pushing to AUR (set in `larkly/aur-lazystack`)

## Test plan

- [ ] Push a pre-release tag to verify the full pipeline
- [ ] Verify all 10 artifacts + SHA256SUMS appear in the GitHub Release
- [ ] Test package installation in debian, fedora, and archlinux containers
- [ ] Verify AUR dispatch triggers PKGBUILD update
