### PR TITLE
feat: accessibility status icons with --plain flag (#60)

### DIFF
--- a/docs/superpowers/plans/2026-03-28-accessibility-status-icons.md
+++ b/docs/superpowers/plans/2026-03-28-accessibility-status-icons.md
@@ -1,0 +1,574 @@
+# Accessibility Status Icons Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Unicode shape icons (●▲✘○↻■) as prefixes to status text across all resource views, with a `--plain` CLI flag to disable.
+
+**Architecture:** A centralized `StatusIcon(status)` function in `shared/styles.go` maps status strings to icon prefixes. Each view prepends the icon at its status render site. A package-level `PlainMode` bool (set via `--plain` flag) disables icons.
+
+**Tech Stack:** Go, Bubble Tea, Lipgloss
+
+**Spec:** `docs/superpowers/specs/2026-03-28-accessibility-status-icons-design.md`
+
+---
+
+### Task 1: Add StatusIcon function and PlainMode to shared/styles.go
+
+**Files:**
+- Modify: `src/internal/shared/styles.go`
+- Create: `src/internal/shared/styles_test.go`
+
+- [ ] **Step 1: Write failing tests for StatusIcon**
+
+```go
+package shared
+
+import "testing"
+
+func TestStatusIcon_KnownStates(t *testing.T) {
+	PlainMode = false
+	tests := []struct {
+		status string
+		want   string
+	}{
+		{"ACTIVE", "● "},
+		{"RUNNING", "● "},
+		{"available", "● "},
+		{"ONLINE", "● "},
+		{"active", "● "},
+		{"BUILD", "▲ "},
+		{"RESIZE", "▲ "},
+		{"NOSTATE", "▲ "},
+		{"ERROR", "✘ "},
+		{"CRASHED", "✘ "},
+		{"DELETED", "✘ "},
+		{"OFFLINE", "✘ "},
+		{"SHUTOFF", "○ "},
+		{"SHUTDOWN", "○ "},
+		{"DOWN", "○ "},
+		{"REBOOT", "↻ "},
+		{"HARD_REBOOT", "↻ "},
+		{"in-use", "↻ "},
+		{"PAUSED", "■ "},
+		{"SUSPENDED", "■ "},
+		{"SHELVED", "■ "},
+		{"deactivated", "■ "},
+	}
+	for _, tt := range tests {
+		got := StatusIcon(tt.status)
+		if got != tt.want {
+			t.Errorf("StatusIcon(%q) = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}
+
+func TestStatusIcon_PendingPrefix(t *testing.T) {
+	PlainMode = false
+	tests := []string{"PENDING_CREATE", "PENDING_UPDATE", "PENDING_DELETE"}
+	for _, s := range tests {
+		got := StatusIcon(s)
+		if got != "▲ " {
+			t.Errorf("StatusIcon(%q) = %q, want %q", s, got, "▲ ")
+		}
+	}
+}
+
+func TestStatusIcon_UnknownState(t *testing.T) {
+	PlainMode = false
+	got := StatusIcon("UNKNOWN_STATE")
+	if got != "" {
+		t.Errorf("StatusIcon(UNKNOWN_STATE) = %q, want empty", got)
+	}
+}
+
+func TestStatusIcon_PlainMode(t *testing.T) {
+	PlainMode = true
+	defer func() { PlainMode = false }()
+	got := StatusIcon("ACTIVE")
+	if got != "" {
+		t.Errorf("StatusIcon in PlainMode = %q, want empty", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd src && go test ./internal/shared/ -v -run TestStatusIcon`
+Expected: FAIL — `StatusIcon` undefined
+
+- [ ] **Step 3: Implement StatusIcon and PlainMode**
+
+Add to `src/internal/shared/styles.go` after the existing `PowerColors` map:
+
+```go
+// PlainMode disables status icons when true (set via --plain flag).
+var PlainMode bool
+
+// statusIconMap maps status strings to their Unicode icon prefix.
+var statusIconMap = map[string]string{
+	// Healthy/Active — ●
+	"ACTIVE":    "● ",
+	"RUNNING":   "● ",
+	"available": "● ",
+	"ONLINE":    "● ",
+	"active":    "● ",
+	// In-progress — ▲
+	"BUILD":         "▲ ",
+	"RESIZE":        "▲ ",
+	"VERIFY_RESIZE": "▲ ",
+	"MIGRATING":     "▲ ",
+	"creating":      "▲ ",
+	"downloading":   "▲ ",
+	"uploading":     "▲ ",
+	"extending":     "▲ ",
+	"saving":        "▲ ",
+	"NOSTATE":       "▲ ",
+	// Error — ✘
+	"ERROR":           "✘ ",
+	"CRASHED":         "✘ ",
+	"DELETED":         "✘ ",
+	"SOFT_DELETED":    "✘ ",
+	"error":           "✘ ",
+	"error_deleting":  "✘ ",
+	"error_restoring": "✘ ",
+	"killed":          "✘ ",
+	"OFFLINE":         "✘ ",
+	// Off/Inactive — ○
+	"SHUTOFF":        "○ ",
+	"SHUTDOWN":       "○ ",
+	"DOWN":           "○ ",
+	"deleting":       "○ ",
+	"deleted":        "○ ",
+	"pending_delete": "○ ",
+	// Transitional — ↻
+	"REBOOT":      "↻ ",
+	"HARD_REBOOT": "↻ ",
+	"in-use":      "↻ ",
+	"queued":      "↻ ",
+	"importing":   "↻ ",
+	"DEGRADED":    "↻ ",
+	"NO_MONITOR":  "↻ ",
+	"DRAINING":    "↻ ",
+	// Paused/Held — ■
+	"PAUSED":            "■ ",
+	"SUSPENDED":         "■ ",
+	"SHELVED":           "■ ",
+	"SHELVED_OFFLOADED": "■ ",
+	"deactivated":       "■ ",
+}
+
+// StatusIcon returns the icon prefix for a status string.
+// Returns "" for unknown statuses or when PlainMode is true.
+func StatusIcon(status string) string {
+	if PlainMode {
+		return ""
+	}
+	if icon, ok := statusIconMap[status]; ok {
+		return icon
+	}
+	if strings.HasPrefix(status, "PENDING_") {
+		return "▲ "
+	}
+	return ""
+}
+```
+
+Add `"strings"` to the import block.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd src && go test ./internal/shared/ -v -run TestStatusIcon`
+Expected: PASS (all 4 test functions)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/internal/shared/styles.go src/internal/shared/styles_test.go
+git commit -m "feat: add StatusIcon function with PlainMode support (#60)"
+```
+
+---
+
+### Task 2: Add --plain CLI flag
+
+**Files:**
+- Modify: `src/cmd/lazystack/main.go:21-28` (flag definitions)
+- Modify: `src/internal/app/app.go:184-191` (Options struct), lines 210-225 and 228-243 (New function)
+
+- [ ] **Step 1: Add Plain field to Options struct**
+
+In `src/internal/app/app.go`, add `Plain bool` to the `Options` struct (line ~190):
+
+```go
+type Options struct {
+	AlwaysPickCloud bool
+	Cloud           string
+	RefreshInterval time.Duration
+	IdleTimeout     time.Duration
+	Version         string
+	CheckUpdate     bool
+	Plain           bool
+}
+```
+
+- [ ] **Step 2: Set shared.PlainMode in New()**
+
+In `src/internal/app/app.go`, add at the top of `func New(opts Options)` (line ~194, before the `clouds` call):
+
+```go
+shared.PlainMode = opts.Plain
+```
+
+- [ ] **Step 3: Add --plain flag to main.go**
+
+In `src/cmd/lazystack/main.go`, add after the existing flag definitions (line ~28):
+
+```go
+plainMode := flag.Bool("plain", false, "disable Unicode status icons")
+```
+
+And in the Options construction (where other flags are mapped to Options fields), add:
+
+```go
+Plain: *plainMode,
+```
+
+- [ ] **Step 4: Verify build compiles**
+
+Run: `cd src && go build ./cmd/lazystack`
+Expected: compiles without errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cmd/lazystack/main.go src/internal/app/app.go
+git commit -m "feat: add --plain CLI flag to disable status icons (#60)"
+```
+
+---
+
+### Task 3: Add icons to server list and detail views
+
+**Files:**
+- Modify: `src/internal/ui/serverlist/serverlist.go:502` (renderServerRow)
+- Modify: `src/internal/ui/serverlist/columns.go:23` (status column MinWidth)
+- Modify: `src/internal/ui/serverdetail/serverdetail.go:216-218` (status rendering)
+
+- [ ] **Step 1: Prepend icon to server list status**
+
+In `src/internal/ui/serverlist/serverlist.go`, change line 502 from:
+
+```go
+statusVal := s.Status + "/" + s.PowerState
+```
+
+to:
+
+```go
+statusVal := shared.StatusIcon(s.Status) + s.Status + "/" + s.PowerState
+```
+
+- [ ] **Step 2: Increase status column MinWidth**
+
+In `src/internal/ui/serverlist/columns.go`, change the status column MinWidth from 18 to 20:
+
+```go
+{Title: "Status", MinWidth: 20, Flex: 0, Priority: 0, Key: "status"},
+```
+
+- [ ] **Step 3: Prepend icon to server detail status**
+
+In `src/internal/ui/serverdetail/serverdetail.go`, change lines 216-218 from:
+
+```go
+if p.label == "Status" {
+    value = StatusStyle(p.value).Render(p.value)
+}
+```
+
+to:
+
+```go
+if p.label == "Status" {
+    value = StatusStyle(p.value).Render(shared.StatusIcon(p.value) + p.value)
+}
+```
+
+- [ ] **Step 4: Verify build and existing tests pass**
+
+Run: `cd src && go build ./cmd/lazystack && go test ./internal/ui/serverlist/ -v`
+Expected: compiles and tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/internal/ui/serverlist/serverlist.go src/internal/ui/serverlist/columns.go src/internal/ui/serverdetail/serverdetail.go
+git commit -m "feat: add status icons to server list and detail views (#60)"
+```
+
+---
+
+### Task 4: Add icons to volume views
+
+**Files:**
+- Modify: `src/internal/ui/volumelist/volumelist.go:433` (status value)
+- Modify: `src/internal/ui/volumelist/volumelist.go:41` (status column MinWidth)
+- Modify: `src/internal/ui/volumedetail/volumedetail.go:210-212` (status rendering)
+
+- [ ] **Step 1: Prepend icon to volume list status**
+
+In `src/internal/ui/volumelist/volumelist.go`, change line 433 from:
+
+```go
+"status":   v.Status,
+```
+
+to:
+
+```go
+"status":   shared.StatusIcon(v.Status) + v.Status,
+```
+
+- [ ] **Step 2: Increase volume status column MinWidth**
+
+Change line 41 MinWidth from 12 to 14.
+
+- [ ] **Step 3: Prepend icon to volume detail status**
+
+In `src/internal/ui/volumedetail/volumedetail.go`, change lines 210-212 from:
+
+```go
+if p.label == "Status" {
+    value = volumeStatusStyle(p.value).Render(p.value)
+}
+```
+
+to:
+
+```go
+if p.label == "Status" {
+    value = volumeStatusStyle(p.value).Render(shared.StatusIcon(p.value) + p.value)
+}
+```
+
+- [ ] **Step 4: Verify build compiles**
+
+Run: `cd src && go build ./cmd/lazystack`
+Expected: compiles without errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/internal/ui/volumelist/volumelist.go src/internal/ui/volumedetail/volumedetail.go
+git commit -m "feat: add status icons to volume list and detail views (#60)"
+```
+
+---
+
+### Task 5: Add icons to image views
+
+**Files:**
+- Modify: `src/internal/ui/imagelist/imagelist.go:402` (status value)
+- Modify: `src/internal/ui/imagelist/imagelist.go:39` (status column MinWidth)
+- Modify: `src/internal/ui/imagedetail/imagedetail.go:190-192` (status rendering)
+
+- [ ] **Step 1: Prepend icon to image list status**
+
+In `src/internal/ui/imagelist/imagelist.go`, change line 402 from:
+
+```go
+"status":     img.Status,
+```
+
+to:
+
+```go
+"status":     shared.StatusIcon(img.Status) + img.Status,
+```
+
+- [ ] **Step 2: Increase image status column MinWidth**
+
+Change line 39 MinWidth from 12 to 14.
+
+- [ ] **Step 3: Prepend icon to image detail status**
+
+In `src/internal/ui/imagedetail/imagedetail.go`, change lines 190-192 from:
+
+```go
+if p.label == "Status" {
+    value = statusStyle(p.value).Render(p.value)
+}
+```
+
+to:
+
+```go
+if p.label == "Status" {
+    value = statusStyle(p.value).Render(shared.StatusIcon(p.value) + p.value)
+}
+```
+
+- [ ] **Step 4: Verify build compiles**
+
+Run: `cd src && go build ./cmd/lazystack`
+Expected: compiles without errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/internal/ui/imagelist/imagelist.go src/internal/ui/imagedetail/imagedetail.go
+git commit -m "feat: add status icons to image list and detail views (#60)"
+```
+
+---
+
+### Task 6: Add icons to floating IP, router, and network views
+
+**Files:**
+- Modify: `src/internal/ui/floatingiplist/floatingiplist.go:256` (status render)
+- Modify: `src/internal/ui/routerlist/routerlist.go:252` (status render)
+- Modify: `src/internal/ui/routerdetail/routerdetail.go:209-212` (status rendering)
+- Modify: `src/internal/ui/networklist/networklist.go:267` (status render)
+
+- [ ] **Step 1: Prepend icon to floating IP status**
+
+In `src/internal/ui/floatingiplist/floatingiplist.go`, change line 256 from:
+
+```go
+statusStr := statusStyle.Width(12).Render(f.Status)
+```
+
+to:
+
+```go
+statusStr := statusStyle.Width(14).Render(shared.StatusIcon(f.Status) + f.Status)
+```
+
+- [ ] **Step 2: Prepend icon to router list status**
+
+In `src/internal/ui/routerlist/routerlist.go`, change line 252 from:
+
+```go
+stStyle.Render(truncate(r.Status, 12)),
+```
+
+to:
+
+```go
+stStyle.Render(shared.StatusIcon(r.Status) + truncate(r.Status, 14)),
+```
+
+Also increase the status width in the row layout if there's a hardcoded width for this column.
+
+- [ ] **Step 3: Prepend icon to router detail status**
+
+In `src/internal/ui/routerdetail/routerdetail.go`, change lines 209-212. For the Status label:
+
+```go
+if p.label == "Status" {
+    value = statusStyle(p.value).Render(shared.StatusIcon(p.value) + p.value)
+}
+```
+
+- [ ] **Step 4: Prepend icon to network list status**
+
+In `src/internal/ui/networklist/networklist.go`, change line 267 from:
+
+```go
+statusStyle.Width(statusW).Render(net.Status),
+```
+
+to:
+
+```go
+statusStyle.Width(statusW).Render(shared.StatusIcon(net.Status) + net.Status),
+```
+
+- [ ] **Step 5: Verify build compiles**
+
+Run: `cd src && go build ./cmd/lazystack`
+Expected: compiles without errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/internal/ui/floatingiplist/floatingiplist.go src/internal/ui/routerlist/routerlist.go src/internal/ui/routerdetail/routerdetail.go src/internal/ui/networklist/networklist.go
+git commit -m "feat: add status icons to floating IP, router, and network views (#60)"
+```
+
+---
+
+### Task 7: Add icons to load balancer and server picker views
+
+**Files:**
+- Modify: `src/internal/ui/lblist/lblist.go:247-248` (dual status render)
+- Modify: `src/internal/ui/lbdetail/lbdetail.go:178-179` (status properties)
+- Modify: `src/internal/ui/serverpicker/serverpicker.go:218` (inline status)
+
+- [ ] **Step 1: Prepend icons to LB list statuses**
+
+In `src/internal/ui/lblist/lblist.go`, change lines 247-248. For provisioning status render:
+
+```go
+psStyle.Render(shared.StatusIcon(lb.ProvisioningStatus) + truncate(lb.ProvisioningStatus, 18)),
+```
+
+For operating status render:
+
+```go
+osStyle.Render(shared.StatusIcon(lb.OperatingStatus) + truncate(lb.OperatingStatus, 16)),
+```
+
+- [ ] **Step 2: Prepend icons to LB detail statuses**
+
+In `src/internal/ui/lbdetail/lbdetail.go`, change the render logic (around line 190-191) where style functions are applied. The rendered value should include the icon:
+
+```go
+if p.style != nil {
+    value = p.style(p.value).Render(shared.StatusIcon(p.value) + p.value)
+```
+
+- [ ] **Step 3: Prepend icon to server picker status**
+
+In `src/internal/ui/serverpicker/serverpicker.go`, change line 218 from:
+
+```go
+line := cursor + style.Render(srv.Name) + " " + statusStyle.Render(srv.Status)
+```
+
+to:
+
+```go
+line := cursor + style.Render(srv.Name) + " " + statusStyle.Render(shared.StatusIcon(srv.Status) + srv.Status)
+```
+
+- [ ] **Step 4: Verify build and all tests pass**
+
+Run: `cd src && go build ./cmd/lazystack && go test ./... -v`
+Expected: compiles and all tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/internal/ui/lblist/lblist.go src/internal/ui/lbdetail/lbdetail.go src/internal/ui/serverpicker/serverpicker.go
+git commit -m "feat: add status icons to load balancer and server picker views (#60)"
+```
+
+---
+
+### Task 8: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd src && go test ./... -v`
+Expected: all tests pass
+
+- [ ] **Step 2: Verify --plain flag works**
+
+Run: `cd src && go build ./cmd/lazystack && ./lazystack --help`
+Expected: `--plain` flag appears in help output with description "disable Unicode status icons"
+
+- [ ] **Step 3: Build final binary**
+
+Run: `cd src && go build -o lazystack ./cmd/lazystack`
+Expected: binary compiles successfully

--- a/docs/superpowers/specs/2026-03-28-accessibility-status-icons-design.md
+++ b/docs/superpowers/specs/2026-03-28-accessibility-status-icons-design.md
@@ -1,0 +1,78 @@
+# Accessibility: Status Icons Design
+
+## Problem
+
+Server status and resource states are communicated primarily through color (Solarized Dark palette). Users who are colorblind or using monochrome terminals cannot distinguish states at a glance. While status text is already displayed (e.g., "ACTIVE/RUNNING"), scanning a list of servers requires reading each status string rather than recognizing a visual pattern.
+
+## Solution
+
+Add Unicode shape icon prefixes to all status indicators across every resource view. Icons encode the status *category* by shape, providing a second visual channel alongside color. A `--plain` CLI flag disables icons for terminals with poor Unicode support.
+
+## Icon Mapping
+
+Six categories cover all resource states. For any unmapped status, return `""` (no icon) to avoid visual noise from unknown states.
+
+States prefixed with `PENDING_` (e.g., `PENDING_CREATE`, `PENDING_UPDATE`, `PENDING_DELETE`) are matched via `strings.HasPrefix`.
+
+| Icon | Category | States |
+|------|----------|--------|
+| ● | Healthy/Active | ACTIVE, RUNNING, available, ONLINE, active |
+| ▲ | In-progress | BUILD, RESIZE, VERIFY_RESIZE, MIGRATING, creating, downloading, uploading, extending, saving, PENDING_*, NOSTATE |
+| ✘ | Error | ERROR, CRASHED, DELETED, SOFT_DELETED, error, error_deleting, error_restoring, killed, OFFLINE |
+| ○ | Off/Inactive | SHUTOFF, SHUTDOWN, DOWN, deleting, deleted, pending_delete |
+| ↻ | Transitional | REBOOT, HARD_REBOOT, in-use, queued, importing, DEGRADED, NO_MONITOR, DRAINING |
+| ■ | Paused/Held | PAUSED, SUSPENDED, SHELVED, SHELVED_OFFLOADED, deactivated |
+
+## Architecture
+
+### `src/internal/shared/styles.go`
+
+Add a `PlainMode` package-level bool and a `StatusIcon(status string) string` function. The function maps a raw status string to its icon prefix (e.g., `"ACTIVE"` → `"● "`). When `PlainMode` is true, it returns `""`. For unmapped statuses, it returns `""`.
+
+This is a new parallel structure (not modifying `StatusColors`): a `statusIconMap` from status string to icon string, plus a `strings.HasPrefix` check for `PENDING_` states.
+
+### `src/cmd/lazystack/main.go` + `src/internal/app/app.go`
+
+Add `--plain` bool flag. Add `Plain bool` to `app.Options`. In `app.New()`, set `shared.PlainMode = opts.Plain` before initializing sub-models.
+
+### View changes
+
+Each view's status rendering prepends `shared.StatusIcon(status)` to the status text before styling. Files to modify:
+
+**List views:**
+- `src/internal/ui/serverlist/serverlist.go` — `renderServerRow()`: prepend icon to `statusVal`
+- `src/internal/ui/volumelist/volumelist.go` — status column rendering
+- `src/internal/ui/imagelist/imagelist.go` — status column rendering
+- `src/internal/ui/floatingiplist/floatingiplist.go` — status column rendering
+- `src/internal/ui/routerlist/routerlist.go` — status column rendering
+- `src/internal/ui/networklist/networklist.go` — status column rendering
+- `src/internal/ui/lblist/lblist.go` — provisioning + operating status rendering
+
+**Detail views:**
+- `src/internal/ui/serverdetail/serverdetail.go` — status field
+- `src/internal/ui/volumedetail/volumedetail.go` — status field
+- `src/internal/ui/imagedetail/imagedetail.go` — status field
+- `src/internal/ui/routerdetail/routerdetail.go` — status field
+- `src/internal/ui/lbdetail/lbdetail.go` — provisioning + operating status fields
+
+**Picker views:**
+- `src/internal/ui/serverpicker/serverpicker.go` — inline server status
+
+### Column width
+
+Status columns may need +2 character width to accommodate the icon prefix. Adjust `MinWidth` in column definitions where applicable.
+
+## CLI Usage
+
+```
+lazystack                  # icons enabled (default)
+lazystack --plain          # icons disabled
+```
+
+## Verification
+
+1. Run `go build ./cmd/lazystack` — compiles without errors
+2. Run `go test ./...` — all tests pass
+3. Launch app, verify icons appear in server list, volume list, image list, floating IP list, router list, LB detail
+4. Launch with `--plain`, verify no icons appear
+5. Visually confirm each status category shows the correct icon shape

--- a/src/cmd/lazystack/main.go
+++ b/src/cmd/lazystack/main.go
@@ -25,6 +25,7 @@ func main() {
 	cloudFlag := flag.String("cloud", "", "connect directly to named cloud, skip picker")
 	refreshSec := flag.Int("refresh", 5, "server list auto-refresh interval in seconds")
 	idleTimeoutMin := flag.Int("idle-timeout", 0, "pause polling after N minutes of no input (0 = disabled)")
+	plainMode := flag.Bool("plain", false, "disable Unicode status icons")
 	flag.Parse()
 
 	if *showVersion {
@@ -70,6 +71,7 @@ func main() {
 		IdleTimeout:     time.Duration(*idleTimeoutMin) * time.Minute,
 		Version:         version,
 		CheckUpdate:     !*noCheckUpdate,
+		Plain:           *plainMode,
 	})
 	p := tea.NewProgram(m)
 	finalModel, err := p.Run()

--- a/src/internal/app/app.go
+++ b/src/internal/app/app.go
@@ -188,10 +188,12 @@ type Options struct {
 	IdleTimeout     time.Duration
 	Version         string
 	CheckUpdate     bool
+	Plain           bool
 }
 
 // New creates the root model.
 func New(opts Options) Model {
+	shared.PlainMode = opts.Plain
 	clouds, err := cloud.ListCloudNames()
 
 	refresh := opts.RefreshInterval

--- a/src/internal/shared/styles.go
+++ b/src/internal/shared/styles.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"image/color"
+	"strings"
 
 	"charm.land/lipgloss/v2"
 )
@@ -46,6 +47,80 @@ var (
 		"NOSTATE":  ColorWarning,
 	}
 
+)
+
+// PlainMode disables status icons when true (set via --plain flag).
+var PlainMode bool
+
+// statusIconMap maps status strings to their Unicode icon prefix.
+var statusIconMap = map[string]string{
+	// Healthy/Active — ●
+	"ACTIVE":    "● ",
+	"RUNNING":   "● ",
+	"available": "● ",
+	"ONLINE":    "● ",
+	"active":    "● ",
+	// In-progress — ▲
+	"BUILD":         "▲ ",
+	"RESIZE":        "▲ ",
+	"VERIFY_RESIZE": "▲ ",
+	"MIGRATING":     "▲ ",
+	"creating":      "▲ ",
+	"downloading":   "▲ ",
+	"uploading":     "▲ ",
+	"extending":     "▲ ",
+	"saving":        "▲ ",
+	"NOSTATE":       "▲ ",
+	// Error — ✘
+	"ERROR":           "✘ ",
+	"CRASHED":         "✘ ",
+	"DELETED":         "✘ ",
+	"SOFT_DELETED":    "✘ ",
+	"error":           "✘ ",
+	"error_deleting":  "✘ ",
+	"error_restoring": "✘ ",
+	"killed":          "✘ ",
+	"OFFLINE":         "✘ ",
+	// Off/Inactive — ○
+	"SHUTOFF":        "○ ",
+	"SHUTDOWN":       "○ ",
+	"DOWN":           "○ ",
+	"deleting":       "○ ",
+	"deleted":        "○ ",
+	"pending_delete": "○ ",
+	// Transitional — ↻
+	"REBOOT":      "↻ ",
+	"HARD_REBOOT": "↻ ",
+	"in-use":      "↻ ",
+	"queued":      "↻ ",
+	"importing":   "↻ ",
+	"DEGRADED":    "↻ ",
+	"NO_MONITOR":  "↻ ",
+	"DRAINING":    "↻ ",
+	// Paused/Held — ■
+	"PAUSED":            "■ ",
+	"SUSPENDED":         "■ ",
+	"SHELVED":           "■ ",
+	"SHELVED_OFFLOADED": "■ ",
+	"deactivated":       "■ ",
+}
+
+// StatusIcon returns the icon prefix for a status string.
+// Returns "" for unknown statuses or when PlainMode is true.
+func StatusIcon(status string) string {
+	if PlainMode {
+		return ""
+	}
+	if icon, ok := statusIconMap[status]; ok {
+		return icon
+	}
+	if strings.HasPrefix(status, "PENDING_") {
+		return "▲ "
+	}
+	return ""
+}
+
+var (
 	StyleTitle = lipgloss.NewStyle().
 			Bold(true).
 			Foreground(ColorPrimary).

--- a/src/internal/shared/styles_test.go
+++ b/src/internal/shared/styles_test.go
@@ -1,0 +1,68 @@
+package shared
+
+import "testing"
+
+func TestStatusIcon_KnownStates(t *testing.T) {
+	PlainMode = false
+	tests := []struct {
+		status string
+		want   string
+	}{
+		{"ACTIVE", "● "},
+		{"RUNNING", "● "},
+		{"available", "● "},
+		{"ONLINE", "● "},
+		{"active", "● "},
+		{"BUILD", "▲ "},
+		{"RESIZE", "▲ "},
+		{"NOSTATE", "▲ "},
+		{"ERROR", "✘ "},
+		{"CRASHED", "✘ "},
+		{"DELETED", "✘ "},
+		{"OFFLINE", "✘ "},
+		{"SHUTOFF", "○ "},
+		{"SHUTDOWN", "○ "},
+		{"DOWN", "○ "},
+		{"REBOOT", "↻ "},
+		{"HARD_REBOOT", "↻ "},
+		{"in-use", "↻ "},
+		{"PAUSED", "■ "},
+		{"SUSPENDED", "■ "},
+		{"SHELVED", "■ "},
+		{"deactivated", "■ "},
+	}
+	for _, tt := range tests {
+		got := StatusIcon(tt.status)
+		if got != tt.want {
+			t.Errorf("StatusIcon(%q) = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}
+
+func TestStatusIcon_PendingPrefix(t *testing.T) {
+	PlainMode = false
+	tests := []string{"PENDING_CREATE", "PENDING_UPDATE", "PENDING_DELETE"}
+	for _, s := range tests {
+		got := StatusIcon(s)
+		if got != "▲ " {
+			t.Errorf("StatusIcon(%q) = %q, want %q", s, got, "▲ ")
+		}
+	}
+}
+
+func TestStatusIcon_UnknownState(t *testing.T) {
+	PlainMode = false
+	got := StatusIcon("UNKNOWN_STATE")
+	if got != "" {
+		t.Errorf("StatusIcon(UNKNOWN_STATE) = %q, want empty", got)
+	}
+}
+
+func TestStatusIcon_PlainMode(t *testing.T) {
+	PlainMode = true
+	defer func() { PlainMode = false }()
+	got := StatusIcon("ACTIVE")
+	if got != "" {
+		t.Errorf("StatusIcon in PlainMode = %q, want empty", got)
+	}
+}

--- a/src/internal/ui/floatingiplist/floatingiplist.go
+++ b/src/internal/ui/floatingiplist/floatingiplist.go
@@ -253,7 +253,7 @@ func (m Model) View() string {
 		}
 
 		line := fmt.Sprintf("%-16s ", f.FloatingIP)
-		statusStr := statusStyle.Width(12).Render(f.Status)
+		statusStr := statusStyle.Width(14).Render(shared.StatusIcon(f.Status) + f.Status)
 		rest := fmt.Sprintf(" %-16s %-36s", fixedIP, portID)
 
 		b.WriteString(cursor + style.Render(line) + statusStr + style.Render(rest) + "\n")

--- a/src/internal/ui/floatingiplist/floatingiplist.go
+++ b/src/internal/ui/floatingiplist/floatingiplist.go
@@ -196,7 +196,7 @@ func (m Model) View() string {
 		width int
 	}{
 		{"Floating IP", 16},
-		{"Status", 12},
+		{"Status", 14},
 		{"Fixed IP", 16},
 		{"Port ID", 36},
 	}

--- a/src/internal/ui/imagedetail/imagedetail.go
+++ b/src/internal/ui/imagedetail/imagedetail.go
@@ -188,7 +188,7 @@ func (m Model) View() string {
 		label := shared.StyleLabel.Render(p.label)
 		value := shared.StyleValue.Render(p.value)
 		if p.label == "Status" {
-			value = statusStyle(p.value).Render(p.value)
+			value = statusStyle(p.value).Render(shared.StatusIcon(p.value) + p.value)
 		}
 		lines = append(lines, fmt.Sprintf("  %s %s", label, value))
 	}

--- a/src/internal/ui/imagelist/imagelist.go
+++ b/src/internal/ui/imagelist/imagelist.go
@@ -36,7 +36,7 @@ type Column struct {
 func defaultColumns() []Column {
 	return []Column{
 		{Title: "Name", MinWidth: 10, Flex: 3, Priority: 0, Key: "name"},
-		{Title: "Status", MinWidth: 12, Flex: 0, Priority: 0, Key: "status"},
+		{Title: "Status", MinWidth: 14, Flex: 0, Priority: 0, Key: "status"},
 		{Title: "Size", MinWidth: 8, Flex: 0, Priority: 0, Key: "size"},
 		{Title: "Min Disk", MinWidth: 8, Flex: 0, Priority: 2, Key: "min_disk"},
 		{Title: "Min RAM", MinWidth: 8, Flex: 0, Priority: 2, Key: "min_ram"},
@@ -399,7 +399,7 @@ func (m Model) View() string {
 
 		values := map[string]string{
 			"name":       name,
-			"status":     img.Status,
+			"status":     shared.StatusIcon(img.Status) + img.Status,
 			"size":       formatSize(img.Size),
 			"min_disk":   fmt.Sprintf("%dGB", img.MinDisk),
 			"min_ram":    fmt.Sprintf("%dMB", img.MinRAM),

--- a/src/internal/ui/lbdetail/lbdetail.go
+++ b/src/internal/ui/lbdetail/lbdetail.go
@@ -188,7 +188,7 @@ func (m Model) View() string {
 		label := shared.StyleLabel.Render(p.label)
 		var value string
 		if p.style != nil {
-			value = p.style(p.value).Render(p.value)
+			value = p.style(p.value).Render(shared.StatusIcon(p.value) + p.value)
 		} else {
 			value = shared.StyleValue.Render(p.value)
 		}

--- a/src/internal/ui/lblist/lblist.go
+++ b/src/internal/ui/lblist/lblist.go
@@ -166,7 +166,7 @@ func (m Model) View() string {
 	}
 
 	// Name column gets remaining width after fixed columns
-	fixedW := 18 + 16 + 14 + 3 + 2 // vip + prov + oper + gaps + prefix
+	fixedW := 18 + 18 + 16 + 3 + 2 // vip + prov + oper + gaps + prefix
 	nameW := m.width - fixedW
 	if nameW < 20 {
 		nameW = 20
@@ -178,8 +178,8 @@ func (m Model) View() string {
 	}{
 		{"Name", nameW},
 		{"VIP Address", 18},
-		{"Prov. Status", 16},
-		{"Oper. Status", 14},
+		{"Prov. Status", 18},
+		{"Oper. Status", 16},
 	}
 	var headerParts []string
 	for i, h := range headerTitles {
@@ -231,8 +231,8 @@ func (m Model) View() string {
 
 		nameStyle := lipgloss.NewStyle().Width(nameW)
 		vipStyle := lipgloss.NewStyle().Width(18)
-		psStyle := provStyle.Width(16)
-		osStyle := operStyle.Width(14)
+		psStyle := provStyle.Width(18)
+		osStyle := operStyle.Width(16)
 
 		if isCursor {
 			nameStyle = nameStyle.Bold(true).Background(rowBg)
@@ -244,8 +244,8 @@ func (m Model) View() string {
 		parts := []string{
 			nameStyle.Render(truncate(name, nameW)),
 			vipStyle.Render(truncate(lb.VipAddress, 18)),
-			psStyle.Render(truncate(lb.ProvisioningStatus, 16)),
-			osStyle.Render(truncate(lb.OperatingStatus, 14)),
+			psStyle.Render(shared.StatusIcon(lb.ProvisioningStatus) + truncate(lb.ProvisioningStatus, 18)),
+			osStyle.Render(shared.StatusIcon(lb.OperatingStatus) + truncate(lb.OperatingStatus, 16)),
 		}
 
 		prefix := "  "

--- a/src/internal/ui/lblist/lblist.go
+++ b/src/internal/ui/lblist/lblist.go
@@ -244,8 +244,8 @@ func (m Model) View() string {
 		parts := []string{
 			nameStyle.Render(truncate(name, nameW)),
 			vipStyle.Render(truncate(lb.VipAddress, 18)),
-			psStyle.Render(shared.StatusIcon(lb.ProvisioningStatus) + truncate(lb.ProvisioningStatus, 18)),
-			osStyle.Render(shared.StatusIcon(lb.OperatingStatus) + truncate(lb.OperatingStatus, 16)),
+			psStyle.Render(shared.StatusIcon(lb.ProvisioningStatus) + truncate(lb.ProvisioningStatus, 16)),
+			osStyle.Render(shared.StatusIcon(lb.OperatingStatus) + truncate(lb.OperatingStatus, 14)),
 		}
 
 		prefix := "  "

--- a/src/internal/ui/networklist/networklist.go
+++ b/src/internal/ui/networklist/networklist.go
@@ -262,7 +262,7 @@ func (m Model) View() string {
 		row := fmt.Sprintf("%s%-*s %s %-*d %-*s",
 			cursor,
 			nameW, truncate(net.Name, nameW),
-			statusStyle.Width(statusW).Render(net.Status),
+			statusStyle.Width(statusW).Render(shared.StatusIcon(net.Status) + net.Status),
 			subnetsW, len(net.SubnetIDs),
 			sharedW, sharedStr,
 		)

--- a/src/internal/ui/networklist/networklist.go
+++ b/src/internal/ui/networklist/networklist.go
@@ -224,7 +224,7 @@ func (m Model) View() string {
 
 	// Header
 	nameW := 25
-	statusW := 10
+	statusW := 12
 	subnetsW := 8
 	sharedW := 8
 	header := fmt.Sprintf("  %-*s %-*s %-*s %-*s",

--- a/src/internal/ui/routerdetail/routerdetail.go
+++ b/src/internal/ui/routerdetail/routerdetail.go
@@ -207,7 +207,7 @@ func (m Model) View() string {
 		label := labelStyle.Render(p.label)
 		var value string
 		if p.label == "Status" {
-			value = statusStyle(p.value).Render(p.value)
+			value = statusStyle(p.value).Render(shared.StatusIcon(p.value) + p.value)
 		} else if p.label == "Admin State" {
 			value = adminStateStyle(p.value).Render(p.value)
 		} else {

--- a/src/internal/ui/routerlist/routerlist.go
+++ b/src/internal/ui/routerlist/routerlist.go
@@ -249,7 +249,7 @@ func (m Model) View() string {
 
 		parts := []string{
 			nameStyle.Render(truncate(name, nameW)),
-			stStyle.Render(shared.StatusIcon(r.Status) + truncate(r.Status, 14)),
+			stStyle.Render(shared.StatusIcon(r.Status) + truncate(r.Status, 12)),
 			gwStyle.Render(truncate(gateway, 20)),
 			rtStyle.Render(truncate(routes, 8)),
 		}

--- a/src/internal/ui/routerlist/routerlist.go
+++ b/src/internal/ui/routerlist/routerlist.go
@@ -166,7 +166,7 @@ func (m Model) View() string {
 	}
 
 	// Name column gets remaining width after fixed columns
-	fixedW := 12 + 20 + 8 + 3 + 2 // status + gateway + routes + gaps + prefix
+	fixedW := 14 + 20 + 8 + 3 + 2 // status + gateway + routes + gaps + prefix
 	nameW := m.width - fixedW
 	if nameW < 20 {
 		nameW = 20
@@ -177,7 +177,7 @@ func (m Model) View() string {
 		width int
 	}{
 		{"Name", nameW},
-		{"Status", 12},
+		{"Status", 14},
 		{"External Gateway", 20},
 		{"Routes", 8},
 	}
@@ -236,7 +236,7 @@ func (m Model) View() string {
 		}
 
 		nameStyle := lipgloss.NewStyle().Width(nameW)
-		stStyle := statusStyle.Width(12)
+		stStyle := statusStyle.Width(14)
 		gwStyle := lipgloss.NewStyle().Width(20)
 		rtStyle := lipgloss.NewStyle().Width(8)
 
@@ -249,7 +249,7 @@ func (m Model) View() string {
 
 		parts := []string{
 			nameStyle.Render(truncate(name, nameW)),
-			stStyle.Render(truncate(r.Status, 12)),
+			stStyle.Render(shared.StatusIcon(r.Status) + truncate(r.Status, 14)),
 			gwStyle.Render(truncate(gateway, 20)),
 			rtStyle.Render(truncate(routes, 8)),
 		}

--- a/src/internal/ui/serverdetail/serverdetail.go
+++ b/src/internal/ui/serverdetail/serverdetail.go
@@ -214,7 +214,7 @@ func (m Model) View() string {
 		label := shared.StyleLabel.Render(p.label)
 		value := shared.StyleValue.Render(p.value)
 		if p.label == "Status" {
-			value = StatusStyle(p.value).Render(p.value)
+			value = StatusStyle(p.value).Render(shared.StatusIcon(p.value) + p.value)
 		}
 		lines = append(lines, fmt.Sprintf("  %s %s", label, value))
 	}

--- a/src/internal/ui/serverlist/columns.go
+++ b/src/internal/ui/serverlist/columns.go
@@ -20,7 +20,7 @@ type Column struct {
 func DefaultColumns() []Column {
 	return []Column{
 		{Title: "Name", MinWidth: 10, Flex: 2, Priority: 0, Key: "name"},
-		{Title: "Status", MinWidth: 18, Flex: 0, Priority: 0, Key: "status"},
+		{Title: "Status", MinWidth: 20, Flex: 0, Priority: 0, Key: "status"},
 		{Title: "IPv4", MinWidth: 12, Flex: 1, Priority: 1, Key: "ipv4"},
 		{Title: "IPv6", MinWidth: 20, Flex: 4, Priority: 5, Key: "ipv6"},
 		{Title: "Floating IP", MinWidth: 12, Flex: 1, Priority: 3, Key: "floating"},

--- a/src/internal/ui/serverlist/serverlist.go
+++ b/src/internal/ui/serverlist/serverlist.go
@@ -499,7 +499,7 @@ func (m Model) renderRow(render func(Column) string) string {
 
 func (m Model) renderServerRow(s compute.Server, cursor bool) string {
 	// Build combined status: "ACTIVE/RUNNING"
-	statusVal := s.Status + "/" + s.PowerState
+	statusVal := shared.StatusIcon(s.Status) + s.Status + "/" + s.PowerState
 
 	// Selection and lock indicators on name
 	nameVal := s.Name

--- a/src/internal/ui/serverpicker/serverpicker.go
+++ b/src/internal/ui/serverpicker/serverpicker.go
@@ -215,7 +215,7 @@ func (m Model) View() string {
 			if srv.Status == "ACTIVE" {
 				statusStyle = statusStyle.Foreground(shared.ColorSuccess)
 			}
-			line := cursor + style.Render(srv.Name) + " " + statusStyle.Render(srv.Status)
+			line := cursor + style.Render(srv.Name) + " " + statusStyle.Render(shared.StatusIcon(srv.Status) + srv.Status)
 			lines = append(lines, line)
 		}
 		body = strings.Join(lines, "\n")

--- a/src/internal/ui/volumedetail/volumedetail.go
+++ b/src/internal/ui/volumedetail/volumedetail.go
@@ -208,7 +208,7 @@ func (m Model) View() string {
 		label := shared.StyleLabel.Render(p.label)
 		value := shared.StyleValue.Render(p.value)
 		if p.label == "Status" {
-			value = volumeStatusStyle(p.value).Render(p.value)
+			value = volumeStatusStyle(p.value).Render(shared.StatusIcon(p.value) + p.value)
 		}
 		lines = append(lines, fmt.Sprintf("  %s %s", label, value))
 	}

--- a/src/internal/ui/volumelist/volumelist.go
+++ b/src/internal/ui/volumelist/volumelist.go
@@ -38,7 +38,7 @@ type Column struct {
 func defaultColumns() []Column {
 	return []Column{
 		{Title: "Name", MinWidth: 10, Flex: 3, Priority: 0, Key: "name"},
-		{Title: "Status", MinWidth: 12, Flex: 0, Priority: 0, Key: "status"},
+		{Title: "Status", MinWidth: 14, Flex: 0, Priority: 0, Key: "status"},
 		{Title: "Size", MinWidth: 6, Flex: 0, Priority: 0, Key: "size"},
 		{Title: "Type", MinWidth: 8, Flex: 1, Priority: 1, Key: "type"},
 		{Title: "Attached To", MinWidth: 10, Flex: 2, Priority: 1, Key: "attached"},
@@ -430,7 +430,7 @@ func (m Model) View() string {
 
 		values := map[string]string{
 			"name":     name,
-			"status":   v.Status,
+			"status":   shared.StatusIcon(v.Status) + v.Status,
 			"size":     fmt.Sprintf("%dGB", v.Size),
 			"type":     v.VolumeType,
 			"attached": attached,


### PR DESCRIPTION
## Summary

- Add Unicode shape icon prefixes (●▲✘○↻■) to status text across all 13 resource views (servers, volumes, images, floating IPs, routers, networks, load balancers, server picker)
- Add `--plain` CLI flag to disable icons for terminals with poor Unicode support
- Centralized `StatusIcon()` function in `shared/styles.go` maps 40+ status strings to 6 icon categories

Closes #60

## Test plan
- [ ] `go test ./...` passes (including new StatusIcon tests)
- [ ] `go build ./cmd/lazystack` compiles
- [ ] Launch app — icons appear next to status text in all list/detail views
- [ ] Launch with `--plain` — no icons appear
- [ ] Verify each icon category: ● (active), ▲ (in-progress), ✘ (error), ○ (off), ↻ (transitional), ■ (paused)
