### PR TITLE
feat: add two-tier context-aware help overlay

### DIFF
--- a/src/internal/app/app.go
+++ b/src/internal/app/app.go
@@ -427,8 +427,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case key.Matches(msg, shared.Keys.Quit) && m.view != viewCloudPicker:
 				return m, tea.Quit
 			case key.Matches(msg, shared.Keys.Help):
-				m.help.Visible = true
-				m.help.View = m.viewName()
+				m.help.Open(m.viewName())
 				return m, nil
 			case key.Matches(msg, shared.Keys.CloudPick) && m.view != viewCloudPicker:
 				return m.switchToCloudPicker()

--- a/src/internal/ui/help/help.go
+++ b/src/internal/ui/help/help.go
@@ -12,183 +12,296 @@ import (
 // ToggleHelpMsg toggles the help overlay.
 type ToggleHelpMsg struct{}
 
+type helpTier int
+
+const (
+	tierClosed   helpTier = 0
+	tierProfiled helpTier = 1
+	tierFull     helpTier = 2
+)
+
 // Model is the help overlay.
 type Model struct {
 	Visible bool
 	View    string // current view context
 	Width   int
 	Height  int
+	tier    helpTier
 	scroll  int
 	lines   []string
 }
 
+type section struct {
+	name  string
+	binds []string
+}
+
+var allSections = []section{
+	{
+		name: "Global",
+		binds: []string{
+			"q / ctrl+c   quit",
+			"?            toggle help",
+			"C            switch cloud",
+			"P            switch project",
+			"1-5 / ←→     switch tab",
+			"Q             resource quotas",
+			"R             force refresh",
+			"pgup/pgdn    page up/down",
+			"s/S           sort / reverse sort",
+			"ctrl+r       restart app",
+		},
+	},
+	{
+		name: "Server List",
+		binds: []string{
+			"↑/k ↓/j      navigate",
+			"enter         view detail",
+			"ctrl+n        create server",
+			"ctrl+d        delete server",
+			"ctrl+o        soft reboot",
+			"p             pause/unpause",
+			"ctrl+z        suspend/resume",
+			"ctrl+e        shelve/unshelve",
+			"o             stop/start",
+			"ctrl+l        lock/unlock",
+			"ctrl+f        resize",
+			"ctrl+g        rebuild",
+			"ctrl+s        snapshot",
+			"r             rename",
+			"ctrl+a        assign floating IP",
+			"L             console log",
+			"a             action history",
+			"space         select/deselect",
+			"/             filter",
+		},
+	},
+	{
+		name: "Server Detail",
+		binds: []string{
+			"↑/k ↓/j      scroll",
+			"ctrl+d        delete server",
+			"ctrl+a        assign floating IP",
+			"ctrl+o        soft reboot",
+			"ctrl+p        hard reboot",
+			"p             pause/unpause",
+			"ctrl+z        suspend/resume",
+			"ctrl+e        shelve/unshelve",
+			"o             stop/start",
+			"ctrl+l        lock/unlock",
+			"ctrl+f        resize",
+			"ctrl+g        rebuild",
+			"ctrl+s        snapshot",
+			"r             rename",
+			"L             console log",
+			"a             action history",
+			"esc           back to list",
+		},
+	},
+	{
+		name: "Console Log",
+		binds: []string{
+			"↑/k ↓/j      scroll",
+			"g             top",
+			"G             bottom",
+			"esc           back",
+		},
+	},
+	{
+		name: "Create Form",
+		binds: []string{
+			"tab / ↓       next field",
+			"shift+tab / ↑ prev field",
+			"enter         open picker / activate button",
+			"ctrl+s        submit",
+			"esc           cancel",
+		},
+	},
+	{
+		name: "Volume List",
+		binds: []string{
+			"↑/k ↓/j      navigate",
+			"enter         view detail",
+			"ctrl+n        create volume",
+			"ctrl+d        delete volume",
+			"ctrl+a        attach to server",
+			"ctrl+t        detach from server",
+			"/             filter",
+		},
+	},
+	{
+		name: "Volume Detail",
+		binds: []string{
+			"↑/k ↓/j      scroll",
+			"ctrl+d        delete volume",
+			"ctrl+a        attach to server",
+			"ctrl+t        detach from server",
+			"esc           back to list",
+		},
+	},
+	{
+		name: "Floating IPs",
+		binds: []string{
+			"↑/k ↓/j      navigate",
+			"ctrl+n        allocate new IP",
+			"ctrl+t        disassociate IP",
+			"ctrl+d        release floating IP",
+		},
+	},
+	{
+		name: "Security Groups",
+		binds: []string{
+			"↑/k ↓/j      navigate groups / rules",
+			"enter         expand / collapse group",
+			"ctrl+n        create group (or add rule in rules)",
+			"ctrl+d        delete group (or rule in rules)",
+			"esc           back to group list",
+		},
+	},
+	{
+		name: "Networks",
+		binds: []string{
+			"↑/k ↓/j      navigate networks / subnets",
+			"enter         expand / collapse subnets",
+			"ctrl+n        create network (or subnet in subnets)",
+			"ctrl+d        delete network (or subnet in subnets)",
+			"esc           back to network list",
+		},
+	},
+	{
+		name: "Routers",
+		binds: []string{
+			"↑/k ↓/j      navigate",
+			"enter         view detail (interfaces)",
+			"ctrl+n        create router",
+			"ctrl+d        delete router",
+			"ctrl+a        add interface (from detail)",
+			"ctrl+t        remove interface (from detail)",
+			"esc           back to list",
+		},
+	},
+	{
+		name: "Key Pairs",
+		binds: []string{
+			"↑/k ↓/j      navigate",
+			"enter         view detail (public key)",
+			"ctrl+n        create / import key pair",
+			"ctrl+d        delete key pair",
+			"esc           back to list",
+		},
+	},
+	{
+		name: "LB List",
+		binds: []string{
+			"↑/k ↓/j      navigate",
+			"enter         view detail",
+			"s/S           sort / reverse sort",
+			"/             filter",
+		},
+	},
+	{
+		name: "LB Detail",
+		binds: []string{
+			"↑/k ↓/j      scroll",
+			"esc           back to list",
+		},
+	},
+	{
+		name: "Image List",
+		binds: []string{
+			"↑/k ↓/j      navigate",
+			"enter         view detail",
+			"ctrl+d        delete image",
+			"d             deactivate image",
+			"s/S           sort / reverse sort",
+			"/             filter",
+		},
+	},
+	{
+		name: "Image Detail",
+		binds: []string{
+			"↑/k ↓/j      scroll",
+			"ctrl+d        delete image",
+			"d             deactivate image",
+			"esc           back to list",
+		},
+	},
+	{
+		name: "Modals",
+		binds: []string{
+			"y             confirm",
+			"n / esc       cancel",
+			"←/→ ↑/↓ tab  navigate buttons",
+			"enter         activate button",
+		},
+	},
+}
+
+// viewSections maps view names to the section names shown in profiled help.
+// "Global" is always prepended automatically.
+var viewSections = map[string][]string{
+	"serverlist":    {"Server List"},
+	"serverdetail":  {"Server Detail"},
+	"servercreate":  {"Create Form"},
+	"consolelog":    {"Console Log"},
+	"actionlog":     {"Console Log"},
+	"volumelist":    {"Volume List"},
+	"volumedetail":  {"Volume Detail"},
+	"volumecreate":  {"Create Form"},
+	"floatingiplist": {"Floating IPs"},
+	"secgroupview":  {"Security Groups"},
+	"networklist":   {"Networks"},
+	"keypairlist":   {"Key Pairs"},
+	"keypairdetail": {"Key Pairs"},
+	"keypaircreate": {"Create Form"},
+	"routerlist":    {"Routers"},
+	"routerdetail":  {"Routers"},
+	"lblist":        {"LB List"},
+	"lbdetail":      {"LB Detail"},
+	"imagelist":     {"Image List"},
+	"imagedetail":   {"Image Detail"},
+	"cloudpicker":   {},
+}
+
 // New creates a help model.
 func New() Model {
-	m := Model{}
-	m.buildLines()
-	return m
+	return Model{}
+}
+
+// Open toggles the help overlay, cycling through tiers.
+func (m *Model) Open(view string) {
+	m.View = view
+	switch m.tier {
+	case tierClosed:
+		m.tier = tierProfiled
+	case tierProfiled:
+		m.tier = tierFull
+	default:
+		m.tier = tierClosed
+	}
+	m.scroll = 0
+	m.Visible = m.tier != tierClosed
+	if m.Visible {
+		m.buildLines()
+	}
 }
 
 func (m *Model) buildLines() {
-	sections := []struct {
-		name  string
-		binds []string
-	}{
-		{
-			name: "Global",
-			binds: []string{
-				"q / ctrl+c   quit",
-				"?            toggle help",
-				"C            switch cloud",
-				"P            switch project",
-				"1-5 / ←→     switch tab",
-				"Q             resource quotas",
-				"R             force refresh",
-				"pgup/pgdn    page up/down",
-				"s/S           sort / reverse sort",
-				"ctrl+r       restart app",
-			},
-		},
-		{
-			name: "Server List",
-			binds: []string{
-				"↑/k ↓/j      navigate",
-				"enter         view detail",
-				"ctrl+n        create server",
-				"ctrl+d        delete server",
-				"ctrl+o        soft reboot",
-				"p             pause/unpause",
-				"ctrl+z        suspend/resume",
-				"ctrl+e        shelve/unshelve",
-				"o             stop/start",
-				"ctrl+l        lock/unlock",
-				"ctrl+f        resize",
-				"ctrl+g        rebuild",
-				"ctrl+s        snapshot",
-				"r             rename",
-				"ctrl+a        assign floating IP",
-				"L             console log",
-				"a             action history",
-				"space         select/deselect",
-				"/             filter",
-			},
-		},
-		{
-			name: "Server Detail",
-			binds: []string{
-				"↑/k ↓/j      scroll",
-				"ctrl+d        delete server",
-				"ctrl+a        assign floating IP",
-				"ctrl+o        soft reboot",
-				"ctrl+p        hard reboot",
-				"p             pause/unpause",
-				"ctrl+z        suspend/resume",
-				"ctrl+e        shelve/unshelve",
-				"o             stop/start",
-				"ctrl+l        lock/unlock",
-				"ctrl+f        resize",
-				"ctrl+g        rebuild",
-				"ctrl+s        snapshot",
-				"r             rename",
-				"L             console log",
-				"a             action history",
-				"esc           back to list",
-			},
-		},
-		{
-			name: "Console Log",
-			binds: []string{
-				"↑/k ↓/j      scroll",
-				"g             top",
-				"G             bottom",
-				"esc           back",
-			},
-		},
-		{
-			name: "Create Form",
-			binds: []string{
-				"tab / ↓       next field",
-				"shift+tab / ↑ prev field",
-				"enter         open picker / activate button",
-				"ctrl+s        submit",
-				"esc           cancel",
-			},
-		},
-		{
-			name: "Volume List / Detail",
-			binds: []string{
-				"↑/k ↓/j      navigate / scroll",
-				"enter         view detail",
-				"ctrl+n        create volume",
-				"ctrl+d        delete volume",
-				"ctrl+a        attach to server",
-				"ctrl+t        detach from server",
-				"esc           back to list",
-			},
-		},
-		{
-			name: "Floating IPs",
-			binds: []string{
-				"↑/k ↓/j      navigate",
-				"ctrl+n        allocate new IP",
-				"ctrl+t        disassociate IP",
-				"ctrl+d        release floating IP",
-			},
-		},
-		{
-			name: "Security Groups",
-			binds: []string{
-				"↑/k ↓/j      navigate groups / rules",
-				"enter         expand / collapse group",
-				"ctrl+n        create group (or add rule in rules)",
-				"ctrl+d        delete group (or rule in rules)",
-				"esc           back to group list",
-			},
-		},
-		{
-			name: "Networks",
-			binds: []string{
-				"↑/k ↓/j      navigate networks / subnets",
-				"enter         expand / collapse subnets",
-				"ctrl+n        create network (or subnet in subnets)",
-				"ctrl+d        delete network (or subnet in subnets)",
-				"esc           back to network list",
-			},
-		},
-		{
-			name: "Routers",
-			binds: []string{
-				"↑/k ↓/j      navigate",
-				"enter         view detail (interfaces)",
-				"ctrl+n        create router",
-				"ctrl+d        delete router",
-				"ctrl+a        add interface (from detail)",
-				"ctrl+t        remove interface (from detail)",
-				"esc           back to list",
-			},
-		},
-		{
-			name: "Key Pairs",
-			binds: []string{
-				"↑/k ↓/j      navigate",
-				"enter         view detail (public key)",
-				"ctrl+n        create / import key pair",
-				"ctrl+d        delete key pair",
-				"esc           back to list",
-			},
-		},
-		{
-			name: "Modals",
-			binds: []string{
-				"y             confirm",
-				"n / esc       cancel",
-				"←/→ ↑/↓ tab  navigate buttons",
-				"enter         activate button",
-			},
-		},
+	m.lines = nil
+
+	var sections []section
+	if m.tier == tierProfiled {
+		// Global + view-specific sections
+		sections = append(sections, findSection("Global"))
+		if names, ok := viewSections[m.View]; ok {
+			for _, name := range names {
+				sections = append(sections, findSection(name))
+			}
+		}
+	} else {
+		sections = allSections
 	}
 
-	m.lines = nil
 	for _, s := range sections {
 		m.lines = append(m.lines, lipgloss.NewStyle().
 			Bold(true).
@@ -201,14 +314,35 @@ func (m *Model) buildLines() {
 	}
 }
 
+func findSection(name string) section {
+	for _, s := range allSections {
+		if s.name == name {
+			return s
+		}
+	}
+	return section{name: name}
+}
+
 // Update handles input.
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch {
-		case key.Matches(msg, shared.Keys.Help), key.Matches(msg, shared.Keys.Back):
-			m.Visible = false
+		case key.Matches(msg, shared.Keys.Help):
+			if m.tier == tierProfiled {
+				m.tier = tierFull
+				m.scroll = 0
+				m.buildLines()
+			} else {
+				m.tier = tierClosed
+				m.scroll = 0
+				m.Visible = false
+			}
+			return m, nil
+		case key.Matches(msg, shared.Keys.Back):
+			m.tier = tierClosed
 			m.scroll = 0
+			m.Visible = false
 			return m, nil
 		case key.Matches(msg, shared.Keys.Down):
 			maxScroll := len(m.lines) - m.viewHeight()
@@ -275,7 +409,12 @@ func (m Model) Render() string {
 		scrollHint = shared.StyleHelp.Render(" ↑↓ scroll •")
 	}
 
-	hint := scrollHint + shared.StyleHelp.Render(" ? or esc to close")
+	var hint string
+	if m.tier == tierProfiled {
+		hint = scrollHint + shared.StyleHelp.Render(" ? all shortcuts • esc close")
+	} else {
+		hint = scrollHint + shared.StyleHelp.Render(" ? or esc to close")
+	}
 
 	content := title + "\n\n" + visible + "\n\n" + hint
 	box := shared.StyleModal.Width(50).Render(content)


### PR DESCRIPTION
## Summary
- First `?` press shows a profiled help view: Global shortcuts + shortcuts specific to the current screen (e.g., server list, volume detail)
- Second `?` press shows the full keyboard shortcut list (previous behavior)
- Third `?` or `Esc` at any point closes the overlay
- Split "Volume List / Detail" into separate sections for exact sub-view help
- Added missing help sections for Load Balancer and Image views (list + detail)

## Test plan
- [ ] From server list: `?` shows Global + Server List only; `?` again shows all; `?` closes
- [ ] From volume detail: `?` shows Global + Volume Detail (not Volume List)
- [ ] `Esc` from either tier closes immediately
- [ ] Scroll resets when switching tiers
- [ ] Hint text shows "? all shortcuts • esc close" on profiled, "? or esc to close" on full
- [ ] Terminal resize while help is open renders correctly
- [ ] Create forms still work (help is gated behind the create-form check)