### PR TITLE
fix: restore Images tab to 3rd position as intended by #62

### DIFF
--- a/src/internal/app/tabs.go
+++ b/src/internal/app/tabs.go
@@ -28,11 +28,11 @@ func DefaultTabs() []TabDef {
 	return []TabDef{
 		{Name: "Servers", Key: "servers"},
 		{Name: "Volumes", Key: "volumes"},
+		{Name: "Images", Key: "images"},
 		{Name: "Floating IPs", Key: "floatingips"},
 		{Name: "Sec Groups", Key: "secgroups"},
 		{Name: "Networks", Key: "networks"},
 		{Name: "Key Pairs", Key: "keypairs"},
-		{Name: "Images", Key: "images"},
 	}
 }
 


### PR DESCRIPTION
## Summary
- PR #62 moved the Images tab from last to 3rd position (after Volumes) for better discoverability
- The reorder was lost when PR #42 was squash-merged afterward, placing Images back at the end
- This restores the intended tab order: Servers → Volumes → Images → Floating IPs → ...

## Test plan
- [ ] Build passes (`go build ./...`)
- [ ] Tests pass (`go test ./...`)
- [ ] Images tab appears as 3rd tab in the tab bar