### PR TITLE
fix: track cursor by resource ID across all list views

### DIFF
--- a/src/internal/ui/floatingiplist/floatingiplist.go
+++ b/src/internal/ui/floatingiplist/floatingiplist.go
@@ -72,10 +72,25 @@ func (m Model) SelectedFIP() *network.FloatingIP {
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case fipsLoadedMsg:
+		var cursorID string
+		if m.cursor >= 0 && m.cursor < len(m.fips) {
+			cursorID = m.fips[m.cursor].ID
+		}
 		m.loading = false
 		m.fips = msg.fips
 		m.err = ""
 		m.sortFIPs()
+		if cursorID != "" {
+			for i, f := range m.fips {
+				if f.ID == cursorID {
+					m.cursor = i
+					break
+				}
+			}
+		}
+		if m.cursor >= len(m.fips) {
+			m.cursor = max(0, len(m.fips)-1)
+		}
 		return m, nil
 
 	case fipsErrMsg:
@@ -106,19 +121,43 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch {
 		case key.Matches(msg, shared.Keys.Sort):
+			var cursorID string
+			if m.cursor >= 0 && m.cursor < len(m.fips) {
+				cursorID = m.fips[m.cursor].ID
+			}
 			m.sortCol = (m.sortCol + 1) % len(fipSortColumns)
 			m.sortAsc = true
 			m.sortHighlight = true
 			m.sortClearAt = time.Now().Add(1500 * time.Millisecond)
 			m.sortFIPs()
+			if cursorID != "" {
+				for i, f := range m.fips {
+					if f.ID == cursorID {
+						m.cursor = i
+						break
+					}
+				}
+			}
 			return m, tea.Tick(1500*time.Millisecond, func(time.Time) tea.Msg {
 				return sortClearMsg{}
 			})
 		case key.Matches(msg, shared.Keys.ReverseSort):
+			var cursorID string
+			if m.cursor >= 0 && m.cursor < len(m.fips) {
+				cursorID = m.fips[m.cursor].ID
+			}
 			m.sortAsc = !m.sortAsc
 			m.sortHighlight = true
 			m.sortClearAt = time.Now().Add(1500 * time.Millisecond)
 			m.sortFIPs()
+			if cursorID != "" {
+				for i, f := range m.fips {
+					if f.ID == cursorID {
+						m.cursor = i
+						break
+					}
+				}
+			}
 			return m, tea.Tick(1500*time.Millisecond, func(time.Time) tea.Msg {
 				return sortClearMsg{}
 			})

--- a/src/internal/ui/imagelist/imagelist.go
+++ b/src/internal/ui/imagelist/imagelist.go
@@ -170,10 +170,25 @@ func (m Model) SelectedImage() *image.Image {
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case imagesLoadedMsg:
+		var cursorID string
+		if m.cursor >= 0 && m.cursor < len(m.images) {
+			cursorID = m.images[m.cursor].ID
+		}
 		m.loading = false
 		m.images = msg.images
 		m.err = ""
 		m.sortImages()
+		if cursorID != "" {
+			for i, img := range m.images {
+				if img.ID == cursorID {
+					m.cursor = i
+					break
+				}
+			}
+		}
+		if m.cursor >= len(m.images) {
+			m.cursor = max(0, len(m.images)-1)
+		}
 		return m, nil
 
 	case imagesErrMsg:
@@ -207,21 +222,45 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		case key.Matches(msg, shared.Keys.Sort):
 			visibleCount := m.visibleColCount()
 			if visibleCount > 0 {
+				var cursorID string
+				if m.cursor >= 0 && m.cursor < len(m.images) {
+					cursorID = m.images[m.cursor].ID
+				}
 				m.sortCol = (m.sortCol + 1) % visibleCount
 				m.sortAsc = true
 				m.sortHighlight = true
 				m.sortClearAt = time.Now().Add(1500 * time.Millisecond)
 				m.sortImages()
+				if cursorID != "" {
+					for i, img := range m.images {
+						if img.ID == cursorID {
+							m.cursor = i
+							break
+						}
+					}
+				}
 				return m, tea.Tick(1500*time.Millisecond, func(time.Time) tea.Msg {
 					return sortClearMsg{}
 				})
 			}
 		case key.Matches(msg, shared.Keys.ReverseSort):
 			if m.visibleColCount() > 0 {
+				var cursorID string
+				if m.cursor >= 0 && m.cursor < len(m.images) {
+					cursorID = m.images[m.cursor].ID
+				}
 				m.sortAsc = !m.sortAsc
 				m.sortHighlight = true
 				m.sortClearAt = time.Now().Add(1500 * time.Millisecond)
 				m.sortImages()
+				if cursorID != "" {
+					for i, img := range m.images {
+						if img.ID == cursorID {
+							m.cursor = i
+							break
+						}
+					}
+				}
 				return m, tea.Tick(1500*time.Millisecond, func(time.Time) tea.Msg {
 					return sortClearMsg{}
 				})

--- a/src/internal/ui/keypairlist/keypairlist.go
+++ b/src/internal/ui/keypairlist/keypairlist.go
@@ -62,10 +62,25 @@ func (m Model) Init() tea.Cmd {
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case keypairsLoadedMsg:
+		var cursorName string
+		if m.cursor >= 0 && m.cursor < len(m.pairs) {
+			cursorName = m.pairs[m.cursor].Name
+		}
 		m.loading = false
 		m.pairs = msg.keypairs
 		m.err = ""
 		m.sortPairs()
+		if cursorName != "" {
+			for i, kp := range m.pairs {
+				if kp.Name == cursorName {
+					m.cursor = i
+					break
+				}
+			}
+		}
+		if m.cursor >= len(m.pairs) {
+			m.cursor = max(0, len(m.pairs)-1)
+		}
 		return m, nil
 
 	case keypairsErrMsg:
@@ -96,19 +111,43 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch {
 		case key.Matches(msg, shared.Keys.Sort):
+			var cursorName string
+			if m.cursor >= 0 && m.cursor < len(m.pairs) {
+				cursorName = m.pairs[m.cursor].Name
+			}
 			m.sortCol = (m.sortCol + 1) % len(kpSortColumns)
 			m.sortAsc = true
 			m.sortHighlight = true
 			m.sortClearAt = time.Now().Add(1500 * time.Millisecond)
 			m.sortPairs()
+			if cursorName != "" {
+				for i, kp := range m.pairs {
+					if kp.Name == cursorName {
+						m.cursor = i
+						break
+					}
+				}
+			}
 			return m, tea.Tick(1500*time.Millisecond, func(time.Time) tea.Msg {
 				return sortClearMsg{}
 			})
 		case key.Matches(msg, shared.Keys.ReverseSort):
+			var cursorName string
+			if m.cursor >= 0 && m.cursor < len(m.pairs) {
+				cursorName = m.pairs[m.cursor].Name
+			}
 			m.sortAsc = !m.sortAsc
 			m.sortHighlight = true
 			m.sortClearAt = time.Now().Add(1500 * time.Millisecond)
 			m.sortPairs()
+			if cursorName != "" {
+				for i, kp := range m.pairs {
+					if kp.Name == cursorName {
+						m.cursor = i
+						break
+					}
+				}
+			}
 			return m, tea.Tick(1500*time.Millisecond, func(time.Time) tea.Msg {
 				return sortClearMsg{}
 			})

--- a/src/internal/ui/lblist/lblist.go
+++ b/src/internal/ui/lblist/lblist.go
@@ -64,10 +64,25 @@ func (m Model) Init() tea.Cmd {
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case lbsLoadedMsg:
+		var cursorID string
+		if m.cursor >= 0 && m.cursor < len(m.lbs) {
+			cursorID = m.lbs[m.cursor].ID
+		}
 		m.loading = false
 		m.lbs = msg.lbs
 		m.err = ""
 		m.sortLBs()
+		if cursorID != "" {
+			for i, lb := range m.lbs {
+				if lb.ID == cursorID {
+					m.cursor = i
+					break
+				}
+			}
+		}
+		if m.cursor >= len(m.lbs) {
+			m.cursor = max(0, len(m.lbs)-1)
+		}
 		return m, nil
 
 	case lbsErrMsg:
@@ -98,19 +113,43 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch {
 		case key.Matches(msg, shared.Keys.Sort):
+			var cursorID string
+			if m.cursor >= 0 && m.cursor < len(m.lbs) {
+				cursorID = m.lbs[m.cursor].ID
+			}
 			m.sortCol = (m.sortCol + 1) % len(lbSortColumns)
 			m.sortAsc = true
 			m.sortHighlight = true
 			m.sortClearAt = time.Now().Add(1500 * time.Millisecond)
 			m.sortLBs()
+			if cursorID != "" {
+				for i, lb := range m.lbs {
+					if lb.ID == cursorID {
+						m.cursor = i
+						break
+					}
+				}
+			}
 			return m, tea.Tick(1500*time.Millisecond, func(time.Time) tea.Msg {
 				return sortClearMsg{}
 			})
 		case key.Matches(msg, shared.Keys.ReverseSort):
+			var cursorID string
+			if m.cursor >= 0 && m.cursor < len(m.lbs) {
+				cursorID = m.lbs[m.cursor].ID
+			}
 			m.sortAsc = !m.sortAsc
 			m.sortHighlight = true
 			m.sortClearAt = time.Now().Add(1500 * time.Millisecond)
 			m.sortLBs()
+			if cursorID != "" {
+				for i, lb := range m.lbs {
+					if lb.ID == cursorID {
+						m.cursor = i
+						break
+					}
+				}
+			}
 			return m, tea.Tick(1500*time.Millisecond, func(time.Time) tea.Msg {
 				return sortClearMsg{}
 			})

--- a/src/internal/ui/networklist/networklist.go
+++ b/src/internal/ui/networklist/networklist.go
@@ -71,12 +71,29 @@ func (m Model) ForceRefresh() tea.Cmd {
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case networksLoadedMsg:
+		var cursorID string
+		if m.cursor >= 0 && m.cursor < len(m.networks) {
+			cursorID = m.networks[m.cursor].ID
+		}
 		m.loading = false
 		m.networks = msg.networks
 		m.subnets = msg.subnets
 		m.ports = msg.ports
 		m.err = ""
-		if m.cursor >= len(m.networks) && len(m.networks) > 0 {
+		if cursorID != "" {
+			found := false
+			for i, n := range m.networks {
+				if n.ID == cursorID {
+					m.cursor = i
+					found = true
+					break
+				}
+			}
+			if !found && m.cursor >= len(m.networks) && len(m.networks) > 0 {
+				m.cursor = len(m.networks) - 1
+				m.inSubnets = false
+			}
+		} else if m.cursor >= len(m.networks) && len(m.networks) > 0 {
 			m.cursor = len(m.networks) - 1
 			m.inSubnets = false
 		}

--- a/src/internal/ui/routerlist/routerlist.go
+++ b/src/internal/ui/routerlist/routerlist.go
@@ -64,10 +64,25 @@ func (m Model) Init() tea.Cmd {
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case routersLoadedMsg:
+		var cursorID string
+		if m.cursor >= 0 && m.cursor < len(m.routers) {
+			cursorID = m.routers[m.cursor].ID
+		}
 		m.loading = false
 		m.routers = msg.routers
 		m.err = ""
 		m.sortRouters()
+		if cursorID != "" {
+			for i, r := range m.routers {
+				if r.ID == cursorID {
+					m.cursor = i
+					break
+				}
+			}
+		}
+		if m.cursor >= len(m.routers) {
+			m.cursor = max(0, len(m.routers)-1)
+		}
 		return m, nil
 
 	case routersErrMsg:
@@ -98,19 +113,43 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch {
 		case key.Matches(msg, shared.Keys.Sort):
+			var cursorID string
+			if m.cursor >= 0 && m.cursor < len(m.routers) {
+				cursorID = m.routers[m.cursor].ID
+			}
 			m.sortCol = (m.sortCol + 1) % len(routerSortColumns)
 			m.sortAsc = true
 			m.sortHighlight = true
 			m.sortClearAt = time.Now().Add(1500 * time.Millisecond)
 			m.sortRouters()
+			if cursorID != "" {
+				for i, r := range m.routers {
+					if r.ID == cursorID {
+						m.cursor = i
+						break
+					}
+				}
+			}
 			return m, tea.Tick(1500*time.Millisecond, func(time.Time) tea.Msg {
 				return sortClearMsg{}
 			})
 		case key.Matches(msg, shared.Keys.ReverseSort):
+			var cursorID string
+			if m.cursor >= 0 && m.cursor < len(m.routers) {
+				cursorID = m.routers[m.cursor].ID
+			}
 			m.sortAsc = !m.sortAsc
 			m.sortHighlight = true
 			m.sortClearAt = time.Now().Add(1500 * time.Millisecond)
 			m.sortRouters()
+			if cursorID != "" {
+				for i, r := range m.routers {
+					if r.ID == cursorID {
+						m.cursor = i
+						break
+					}
+				}
+			}
 			return m, tea.Tick(1500*time.Millisecond, func(time.Time) tea.Msg {
 				return sortClearMsg{}
 			})

--- a/src/internal/ui/secgroupview/secgroupview.go
+++ b/src/internal/ui/secgroupview/secgroupview.go
@@ -60,14 +60,30 @@ func (m Model) Init() tea.Cmd {
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case sgLoadedMsg:
+		var cursorID string
+		if m.cursor >= 0 && m.cursor < len(m.groups) {
+			cursorID = m.groups[m.cursor].ID
+		}
 		m.loading = false
 		m.groups = msg.groups
 		m.groupNames = make(map[string]string)
 		for _, g := range msg.groups {
 			m.groupNames[g.ID] = g.Name
 		}
-		// Clamp cursor if list shrunk (e.g. after delete)
-		if m.cursor >= len(m.groups) && len(m.groups) > 0 {
+		if cursorID != "" {
+			found := false
+			for i, g := range m.groups {
+				if g.ID == cursorID {
+					m.cursor = i
+					found = true
+					break
+				}
+			}
+			if !found && m.cursor >= len(m.groups) && len(m.groups) > 0 {
+				m.cursor = len(m.groups) - 1
+				m.inRules = false
+			}
+		} else if m.cursor >= len(m.groups) && len(m.groups) > 0 {
 			m.cursor = len(m.groups) - 1
 			m.inRules = false
 		}

--- a/src/internal/ui/serverlist/serverlist.go
+++ b/src/internal/ui/serverlist/serverlist.go
@@ -180,21 +180,45 @@ func (m Model) updateNormal(msg tea.KeyMsg) (Model, tea.Cmd) {
 	case key.Matches(msg, shared.Keys.Sort):
 		visibleCount := m.visibleColCount()
 		if visibleCount > 0 {
+			var cursorID string
+			if m.cursor >= 0 && m.cursor < len(m.filtered) {
+				cursorID = m.filtered[m.cursor].ID
+			}
 			m.sortCol = (m.sortCol + 1) % visibleCount
 			m.sortAsc = true
 			m.sortHighlight = true
 			m.sortClearAt = time.Now().Add(1500 * time.Millisecond)
 			m.sortServers()
+			if cursorID != "" {
+				for i, s := range m.filtered {
+					if s.ID == cursorID {
+						m.cursor = i
+						break
+					}
+				}
+			}
 			return m, tea.Tick(1500*time.Millisecond, func(time.Time) tea.Msg {
 				return sortClearMsg{}
 			})
 		}
 	case key.Matches(msg, shared.Keys.ReverseSort):
 		if m.visibleColCount() > 0 {
+			var cursorID string
+			if m.cursor >= 0 && m.cursor < len(m.filtered) {
+				cursorID = m.filtered[m.cursor].ID
+			}
 			m.sortAsc = !m.sortAsc
 			m.sortHighlight = true
 			m.sortClearAt = time.Now().Add(1500 * time.Millisecond)
 			m.sortServers()
+			if cursorID != "" {
+				for i, s := range m.filtered {
+					if s.ID == cursorID {
+						m.cursor = i
+						break
+					}
+				}
+			}
 			return m, tea.Tick(1500*time.Millisecond, func(time.Time) tea.Msg {
 				return sortClearMsg{}
 			})
@@ -280,6 +304,10 @@ func (m Model) updateFilter(msg tea.KeyMsg) (Model, tea.Cmd) {
 }
 
 func (m *Model) applyFilter() {
+	var cursorID string
+	if m.cursor >= 0 && m.cursor < len(m.filtered) {
+		cursorID = m.filtered[m.cursor].ID
+	}
 	query := strings.ToLower(m.filter.Value())
 	if query == "" {
 		m.filtered = m.servers
@@ -297,11 +325,19 @@ func (m *Model) applyFilter() {
 			}
 		}
 	}
+	m.sortServers()
+	if cursorID != "" {
+		for i, s := range m.filtered {
+			if s.ID == cursorID {
+				m.cursor = i
+				break
+			}
+		}
+	}
 	if m.cursor >= len(m.filtered) {
 		m.cursor = max(0, len(m.filtered)-1)
 	}
 	m.scrollOff = 0
-	m.sortServers()
 }
 
 func (m Model) visibleColCount() int {

--- a/src/internal/ui/volumelist/volumelist.go
+++ b/src/internal/ui/volumelist/volumelist.go
@@ -178,10 +178,25 @@ func (m Model) SelectedVolume() *volume.Volume {
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case volumesLoadedMsg:
+		var cursorID string
+		if m.cursor >= 0 && m.cursor < len(m.volumes) {
+			cursorID = m.volumes[m.cursor].ID
+		}
 		m.loading = false
 		m.volumes = msg.volumes
 		m.err = ""
 		m.sortVolumes()
+		if cursorID != "" {
+			for i, v := range m.volumes {
+				if v.ID == cursorID {
+					m.cursor = i
+					break
+				}
+			}
+		}
+		if m.cursor >= len(m.volumes) {
+			m.cursor = max(0, len(m.volumes)-1)
+		}
 		m.applyHighlight()
 		return m, m.fetchMissingServerNames()
 
@@ -222,21 +237,45 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		case key.Matches(msg, shared.Keys.Sort):
 			visibleCount := m.visibleColCount()
 			if visibleCount > 0 {
+				var cursorID string
+				if m.cursor >= 0 && m.cursor < len(m.volumes) {
+					cursorID = m.volumes[m.cursor].ID
+				}
 				m.sortCol = (m.sortCol + 1) % visibleCount
 				m.sortAsc = true
 				m.sortHighlight = true
 				m.sortClearAt = time.Now().Add(1500 * time.Millisecond)
 				m.sortVolumes()
+				if cursorID != "" {
+					for i, v := range m.volumes {
+						if v.ID == cursorID {
+							m.cursor = i
+							break
+						}
+					}
+				}
 				return m, tea.Tick(1500*time.Millisecond, func(time.Time) tea.Msg {
 					return sortClearMsg{}
 				})
 			}
 		case key.Matches(msg, shared.Keys.ReverseSort):
 			if m.visibleColCount() > 0 {
+				var cursorID string
+				if m.cursor >= 0 && m.cursor < len(m.volumes) {
+					cursorID = m.volumes[m.cursor].ID
+				}
 				m.sortAsc = !m.sortAsc
 				m.sortHighlight = true
 				m.sortClearAt = time.Now().Add(1500 * time.Millisecond)
 				m.sortVolumes()
+				if cursorID != "" {
+					for i, v := range m.volumes {
+						if v.ID == cursorID {
+							m.cursor = i
+							break
+						}
+					}
+				}
 				return m, tea.Tick(1500*time.Millisecond, func(time.Time) tea.Msg {
 					return sortClearMsg{}
 				})


### PR DESCRIPTION
## Summary
- Cursor now follows the same resource by ID (or Name for keypairs) instead of staying at the same row index when lists auto-refresh, re-sort, or items are added/removed
- Fixes disorienting cursor jumps during navigation when tick-refresh causes re-sorting, and when returning from detail views after deletion
- Applied consistently across all 9 list views: serverlist, volumelist, routerlist, lblist, imagelist, keypairlist, floatingiplist, networklist, secgroupview

## Test plan
- [ ] Select a resource in any list, wait for auto-refresh tick, verify cursor stays on the same resource
- [ ] Change sort column/direction, verify cursor follows the resource
- [ ] Delete a resource from a detail view, verify cursor stays at a valid position
- [ ] Filter the server list while cursor is on a resource, verify cursor tracks correctly