### PR TITLE
fix: move Images tab to 3rd position in runtime tab builder

### DIFF
--- a/src/internal/app/app.go
+++ b/src/internal/app/app.go
@@ -771,6 +771,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.BlockStorageClient != nil {
 			m.tabs = append(m.tabs, TabDef{Name: "Volumes", Key: "volumes"})
 		}
+		m.tabs = append(m.tabs, TabDef{Name: "Images", Key: "images"})
 		m.tabs = append(m.tabs, TabDef{Name: "Floating IPs", Key: "floatingips"})
 		m.tabs = append(m.tabs, TabDef{Name: "Sec Groups", Key: "secgroups"})
 		m.tabs = append(m.tabs, TabDef{Name: "Networks", Key: "networks"})
@@ -779,7 +780,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.tabs = append(m.tabs, TabDef{Name: "Load Balancers", Key: "loadbalancers"})
 		}
 		m.tabs = append(m.tabs, TabDef{Name: "Key Pairs", Key: "keypairs"})
-		m.tabs = append(m.tabs, TabDef{Name: "Images", Key: "images"})
 		m.tabInited = make([]bool, len(m.tabs))
 		m.activeTab = 0
 		m.statusBar.CloudName = m.cloudName


### PR DESCRIPTION
## Summary
- fe287d3 fixed `DefaultTabs()` in `tabs.go` but missed the dynamic tab list built in `app.go` after connecting to the cloud
- Images tab remained last at runtime, defeating the intent of PR #62
- Moved Images to 3rd position (after Volumes) in the runtime tab builder to match `DefaultTabs()`

## Test plan
- [ ] Launch app and verify Images tab appears as 3rd tab (after Servers, Volumes)
- [ ] Verify tab order matches `DefaultTabs()` in `tabs.go`
- [ ] Verify number key shortcuts (1-7) map to correct tabs