### PR TITLE
feat: add persistent config system with runtime editor

### DIFF
--- a/src/cmd/lazystack/main.go
+++ b/src/cmd/lazystack/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/larkly/lazystack/internal/app"
 	"github.com/larkly/lazystack/internal/cloud"
+	"github.com/larkly/lazystack/internal/config"
 	"github.com/larkly/lazystack/internal/selfupdate"
 	"charm.land/bubbletea/v2"
 )
@@ -52,6 +53,35 @@ func main() {
 		return
 	}
 
+	cfg, cfgErr := config.Load()
+	if cfgErr != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to load config: %v\n", cfgErr)
+	}
+
+	// Detect which CLI flags were explicitly set
+	var cliFlags config.CLIFlags
+	flag.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "refresh":
+			d := time.Duration(*refreshSec) * time.Second
+			cliFlags.RefreshInterval = &d
+		case "idle-timeout":
+			d := time.Duration(*idleTimeoutMin) * time.Minute
+			cliFlags.IdleTimeout = &d
+		case "plain":
+			cliFlags.PlainMode = plainMode
+		case "no-check-update":
+			v := !*noCheckUpdate
+			cliFlags.CheckForUpdates = &v
+		case "pick-cloud":
+			cliFlags.AlwaysPickCloud = alwaysPick
+		}
+	})
+	cliFlags.Cloud = *cloudFlag
+
+	cfg = config.Merge(cfg, cliFlags)
+	config.ApplyAll(cfg)
+
 	if *cloudFlag != "" {
 		clouds, err := cloud.ListCloudNames()
 		if err != nil {
@@ -65,13 +95,14 @@ func main() {
 	}
 
 	m := app.New(app.Options{
-		AlwaysPickCloud: *alwaysPick,
-		Cloud:           *cloudFlag,
-		RefreshInterval: time.Duration(*refreshSec) * time.Second,
-		IdleTimeout:     time.Duration(*idleTimeoutMin) * time.Minute,
+		AlwaysPickCloud: cfg.General.AlwaysPickCloud,
+		Cloud:           cliFlags.Cloud,
+		RefreshInterval: time.Duration(cfg.General.RefreshInterval) * time.Second,
+		IdleTimeout:     time.Duration(cfg.General.IdleTimeout) * time.Minute,
 		Version:         version,
-		CheckUpdate:     !*noCheckUpdate,
-		Plain:           *plainMode,
+		CheckUpdate:     cfg.General.CheckForUpdates,
+		Plain:           cfg.General.PlainMode,
+		Config:          &cfg,
 	})
 	p := tea.NewProgram(m)
 	finalModel, err := p.Run()

--- a/src/internal/app/app.go
+++ b/src/internal/app/app.go
@@ -11,8 +11,10 @@ import (
 	"github.com/larkly/lazystack/internal/selfupdate"
 	"github.com/larkly/lazystack/internal/ssh"
 	"github.com/larkly/lazystack/internal/shared"
+	"github.com/larkly/lazystack/internal/config"
 	"github.com/larkly/lazystack/internal/ui/actionlog"
 	"github.com/larkly/lazystack/internal/ui/cloneprogress"
+	"github.com/larkly/lazystack/internal/ui/configview"
 	"github.com/larkly/lazystack/internal/ui/cloudpicker"
 	"github.com/larkly/lazystack/internal/ui/consolelog"
 	"github.com/larkly/lazystack/internal/ui/fippicker"
@@ -159,6 +161,7 @@ type Model struct {
 	tabInited []bool
 	help         help.Model
 	quotaView    quotaview.Model
+	configView   configview.Model
 	confirm      modal.ConfirmModel
 	errModal     modal.ErrorModel
 	activeModal  modalType
@@ -198,6 +201,7 @@ type Options struct {
 	Version         string
 	CheckUpdate     bool
 	Plain           bool
+	Config          *config.Config
 }
 
 // New creates the root model.
@@ -224,6 +228,7 @@ func New(opts Options) Model {
 			statusBar:       statusbar.New(opts.Version),
 			help:            help.New(),
 			quotaView:       quotaview.New(),
+			configView:      configview.New(opts.Config),
 			minWidth:        80,
 			minHeight:       20,
 			autoCloud:       autoName,
@@ -243,6 +248,7 @@ func New(opts Options) Model {
 		statusBar:       statusbar.New(opts.Version),
 		help:            help.New(),
 		quotaView:       quotaview.New(),
+		configView:      configview.New(opts.Config),
 		minWidth:        80,
 		minHeight:       20,
 		refreshInterval: refresh,
@@ -306,6 +312,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.subnetPicker.SetSize(m.width, m.height)
 		m.projectPicker.SetSize(m.width, m.height)
 		m.cloneProgress.SetSize(m.width, m.height)
+		m.configView.Width = m.width
+		m.configView.Height = m.height
 		m.statusBar.Width = m.width
 		return m.updateActiveView(msg)
 
@@ -327,6 +335,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.quotaView.Visible {
 			var cmd tea.Cmd
 			m.quotaView, cmd = m.quotaView.Update(msg)
+			return m, cmd
+		}
+
+		if m.configView.Visible {
+			var cmd tea.Cmd
+			m.configView, cmd = m.configView.Update(msg)
 			return m, cmd
 		}
 
@@ -476,6 +490,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				cmd := m.quotaView.Open()
 				return m, cmd
+			case key.Matches(msg, shared.Keys.Config) && m.view != viewCloudPicker:
+				m.configView.Width = m.width
+				m.configView.Height = m.height
+				m.configView.Open()
+				return m, nil
 			}
 
 			// Back-navigation from cross-resource jump
@@ -898,6 +917,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.restart = true
 		return m, tea.Quit
+
+	case shared.ConfigChangedMsg:
+		m.refreshInterval = time.Duration(m.configView.Cfg().General.RefreshInterval) * time.Second
+		m.idleTimeout = time.Duration(m.configView.Cfg().General.IdleTimeout) * time.Minute
+		return m, nil
 
 	case shared.ViewChangeMsg:
 		return m.handleViewChange(msg)

--- a/src/internal/app/render.go
+++ b/src/internal/app/render.go
@@ -76,6 +76,10 @@ func (m Model) viewContent() string {
 		return m.quotaView.Render()
 	}
 
+	if m.configView.Visible {
+		return m.configView.Render()
+	}
+
 	if m.help.Visible {
 		return m.help.Render()
 	}

--- a/src/internal/config/apply.go
+++ b/src/internal/config/apply.go
@@ -1,0 +1,203 @@
+package config
+
+import (
+	"strings"
+
+	"github.com/larkly/lazystack/internal/shared"
+	"charm.land/bubbles/v2/key"
+	"charm.land/lipgloss/v2"
+)
+
+// ApplyAll applies all config sections to the shared globals.
+func ApplyAll(cfg Config) {
+	ApplyGeneral(cfg.General)
+	ApplyColors(cfg.Colors)
+	ApplyKeybindings(cfg.Keybindings)
+}
+
+// ApplyGeneral sets shared.PlainMode from config.
+func ApplyGeneral(g GeneralConfig) {
+	shared.PlainMode = g.PlainMode
+}
+
+// ApplyColors sets shared.Color* vars and rebuilds shared.Style* vars.
+func ApplyColors(c ColorConfig) {
+	if c.Primary != "" {
+		shared.ColorPrimary = lipgloss.Color(c.Primary)
+	}
+	if c.Secondary != "" {
+		shared.ColorSecondary = lipgloss.Color(c.Secondary)
+	}
+	if c.Success != "" {
+		shared.ColorSuccess = lipgloss.Color(c.Success)
+	}
+	if c.Warning != "" {
+		shared.ColorWarning = lipgloss.Color(c.Warning)
+	}
+	if c.Error != "" {
+		shared.ColorError = lipgloss.Color(c.Error)
+	}
+	if c.Muted != "" {
+		shared.ColorMuted = lipgloss.Color(c.Muted)
+	}
+	if c.Bg != "" {
+		shared.ColorBg = lipgloss.Color(c.Bg)
+	}
+	if c.Fg != "" {
+		shared.ColorFg = lipgloss.Color(c.Fg)
+	}
+	if c.Highlight != "" {
+		shared.ColorHighlight = lipgloss.Color(c.Highlight)
+	}
+	if c.Cyan != "" {
+		shared.ColorCyan = lipgloss.Color(c.Cyan)
+	}
+
+	shared.RebuildStyles()
+}
+
+// keybindingFieldMap maps config keybinding names to KeyMap field setters.
+var keybindingFieldMap = map[string]func(b key.Binding){
+	"quit":            func(b key.Binding) { shared.Keys.Quit = b },
+	"help":            func(b key.Binding) { shared.Keys.Help = b },
+	"cloud_pick":      func(b key.Binding) { shared.Keys.CloudPick = b },
+	"filter":          func(b key.Binding) { shared.Keys.Filter = b },
+	"enter":           func(b key.Binding) { shared.Keys.Enter = b },
+	"back":            func(b key.Binding) { shared.Keys.Back = b },
+	"create":          func(b key.Binding) { shared.Keys.Create = b },
+	"delete":          func(b key.Binding) { shared.Keys.Delete = b },
+	"reboot":          func(b key.Binding) { shared.Keys.Reboot = b },
+	"hard_reboot":     func(b key.Binding) { shared.Keys.HardReboot = b },
+	"refresh":         func(b key.Binding) { shared.Keys.Refresh = b },
+	"up":              func(b key.Binding) { shared.Keys.Up = b },
+	"down":            func(b key.Binding) { shared.Keys.Down = b },
+	"left":            func(b key.Binding) { shared.Keys.Left = b },
+	"right":           func(b key.Binding) { shared.Keys.Right = b },
+	"tab":             func(b key.Binding) { shared.Keys.Tab = b },
+	"shift_tab":       func(b key.Binding) { shared.Keys.ShiftTab = b },
+	"pause":           func(b key.Binding) { shared.Keys.Pause = b },
+	"suspend":         func(b key.Binding) { shared.Keys.Suspend = b },
+	"shelve":          func(b key.Binding) { shared.Keys.Shelve = b },
+	"resize":          func(b key.Binding) { shared.Keys.Resize = b },
+	"confirm_resize":  func(b key.Binding) { shared.Keys.ConfirmResize = b },
+	"revert_resize":   func(b key.Binding) { shared.Keys.RevertResize = b },
+	"actions":         func(b key.Binding) { shared.Keys.Actions = b },
+	"console":         func(b key.Binding) { shared.Keys.Console = b },
+	"select":          func(b key.Binding) { shared.Keys.Select = b },
+	"confirm":         func(b key.Binding) { shared.Keys.Confirm = b },
+	"deny":            func(b key.Binding) { shared.Keys.Deny = b },
+	"restart":         func(b key.Binding) { shared.Keys.Restart = b },
+	"attach":          func(b key.Binding) { shared.Keys.Attach = b },
+	"detach":          func(b key.Binding) { shared.Keys.Detach = b },
+	"allocate":        func(b key.Binding) { shared.Keys.Allocate = b },
+	"page_up":         func(b key.Binding) { shared.Keys.PageUp = b },
+	"page_down":       func(b key.Binding) { shared.Keys.PageDown = b },
+	"sort":            func(b key.Binding) { shared.Keys.Sort = b },
+	"reverse_sort":    func(b key.Binding) { shared.Keys.ReverseSort = b },
+	"project_pick":    func(b key.Binding) { shared.Keys.ProjectPick = b },
+	"quota":           func(b key.Binding) { shared.Keys.Quota = b },
+	"stop_start":      func(b key.Binding) { shared.Keys.StopStart = b },
+	"lock":            func(b key.Binding) { shared.Keys.Lock = b },
+	"rename":          func(b key.Binding) { shared.Keys.Rename = b },
+	"rebuild":         func(b key.Binding) { shared.Keys.Rebuild = b },
+	"snapshot":        func(b key.Binding) { shared.Keys.Snapshot = b },
+	"deactivate":      func(b key.Binding) { shared.Keys.Deactivate = b },
+	"rescue":          func(b key.Binding) { shared.Keys.Rescue = b },
+	"clone":           func(b key.Binding) { shared.Keys.Clone = b },
+	"jump_volumes":    func(b key.Binding) { shared.Keys.JumpVolumes = b },
+	"jump_sec_groups": func(b key.Binding) { shared.Keys.JumpSecGroups = b },
+	"jump_networks":   func(b key.Binding) { shared.Keys.JumpNetworks = b },
+	"ssh":             func(b key.Binding) { shared.Keys.SSH = b },
+	"copy_ssh":        func(b key.Binding) { shared.Keys.CopySSH = b },
+	"console_url":     func(b key.Binding) { shared.Keys.ConsoleURL = b },
+	"config":          func(b key.Binding) { shared.Keys.Config = b },
+}
+
+// defaultHelpText maps config keybinding names to their help descriptions.
+var defaultHelpText = map[string]string{
+	"quit":            "quit",
+	"help":            "help",
+	"cloud_pick":      "switch cloud",
+	"filter":          "filter",
+	"enter":           "select",
+	"back":            "back",
+	"create":          "create",
+	"delete":          "delete",
+	"reboot":          "soft reboot",
+	"hard_reboot":     "hard reboot",
+	"refresh":         "refresh",
+	"up":              "up",
+	"down":            "down",
+	"left":            "left",
+	"right":           "right",
+	"tab":             "next field",
+	"shift_tab":       "prev field",
+	"pause":           "pause/unpause",
+	"suspend":         "suspend/resume",
+	"shelve":          "shelve/unshelve",
+	"resize":          "resize",
+	"confirm_resize":  "confirm resize",
+	"revert_resize":   "revert resize",
+	"actions":         "action history",
+	"console":         "console log",
+	"select":          "select",
+	"confirm":         "confirm",
+	"deny":            "cancel",
+	"restart":         "restart",
+	"attach":          "attach",
+	"detach":          "detach",
+	"allocate":        "allocate",
+	"page_up":         "page up",
+	"page_down":       "page down",
+	"sort":            "sort",
+	"reverse_sort":    "reverse sort",
+	"project_pick":    "switch project",
+	"quota":           "quotas",
+	"stop_start":      "stop/start",
+	"lock":            "lock/unlock",
+	"rename":          "rename",
+	"rebuild":         "rebuild",
+	"snapshot":        "snapshot",
+	"deactivate":      "deactivate/reactivate",
+	"rescue":          "rescue/unrescue",
+	"clone":           "clone",
+	"jump_volumes":    "jump to volumes",
+	"jump_sec_groups": "jump to sec groups",
+	"jump_networks":   "jump to networks",
+	"ssh":             "SSH into server",
+	"copy_ssh":        "copy SSH command",
+	"console_url":     "console URL (noVNC)",
+	"config":          "config",
+}
+
+// ApplyKeybindings sets shared.Keys fields from the config map.
+func ApplyKeybindings(kb map[string]string) {
+	if kb == nil {
+		return
+	}
+	for name, keys := range kb {
+		setter, ok := keybindingFieldMap[name]
+		if !ok {
+			continue
+		}
+		keyList := strings.Split(keys, ",")
+		for i := range keyList {
+			keyList[i] = strings.TrimSpace(keyList[i])
+		}
+
+		helpText := name
+		if ht, ok := defaultHelpText[name]; ok {
+			helpText = ht
+		}
+
+		helpKey := keys
+		if len(keyList) > 0 {
+			helpKey = keyList[0]
+		}
+
+		setter(key.NewBinding(
+			key.WithKeys(keyList...),
+			key.WithHelp(helpKey, helpText),
+		))
+	}
+}

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -1,0 +1,305 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config is the full persisted configuration.
+type Config struct {
+	General     GeneralConfig     `yaml:"general"`
+	Colors      ColorConfig       `yaml:"colors"`
+	Keybindings map[string]string `yaml:"keybindings,omitempty"`
+}
+
+// GeneralConfig holds non-visual, non-keybinding settings.
+type GeneralConfig struct {
+	RefreshInterval int  `yaml:"refresh_interval"`
+	IdleTimeout     int  `yaml:"idle_timeout"`
+	PlainMode       bool `yaml:"plain_mode"`
+	CheckForUpdates bool `yaml:"check_for_updates"`
+	AlwaysPickCloud bool `yaml:"always_pick_cloud"`
+}
+
+// ColorConfig holds hex color strings for the UI palette.
+type ColorConfig struct {
+	Primary   string `yaml:"primary"`
+	Secondary string `yaml:"secondary"`
+	Success   string `yaml:"success"`
+	Warning   string `yaml:"warning"`
+	Error     string `yaml:"error"`
+	Muted     string `yaml:"muted"`
+	Bg        string `yaml:"bg"`
+	Fg        string `yaml:"fg"`
+	Highlight string `yaml:"highlight"`
+	Cyan      string `yaml:"cyan"`
+}
+
+// CLIFlags captures which CLI flags were explicitly set.
+// Nil pointers mean "not set by user" (use config file value).
+type CLIFlags struct {
+	RefreshInterval *time.Duration
+	IdleTimeout     *time.Duration
+	PlainMode       *bool
+	CheckForUpdates *bool
+	AlwaysPickCloud *bool
+	Cloud           string
+}
+
+// DefaultPath returns ~/.config/lazystack/config.yaml.
+func DefaultPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "lazystack", "config.yaml")
+}
+
+// Defaults returns the hardcoded default configuration.
+func Defaults() Config {
+	return Config{
+		General: GeneralConfig{
+			RefreshInterval: 5,
+			IdleTimeout:     0,
+			PlainMode:       false,
+			CheckForUpdates: true,
+			AlwaysPickCloud: false,
+		},
+		Colors: ColorConfig{
+			Primary:   "#7D56F4",
+			Secondary: "#6C71C4",
+			Success:   "#2AA198",
+			Warning:   "#B58900",
+			Error:     "#DC322F",
+			Muted:     "#657B83",
+			Bg:        "#002B36",
+			Fg:        "#839496",
+			Highlight: "#FDF6E3",
+			Cyan:      "#2AA198",
+		},
+		Keybindings: DefaultKeybindings(),
+	}
+}
+
+// DefaultKeybindings returns the default key bindings map.
+func DefaultKeybindings() map[string]string {
+	return map[string]string{
+		"quit":           "q,ctrl+c",
+		"help":           "?",
+		"cloud_pick":     "C",
+		"filter":         "/",
+		"enter":          "enter",
+		"back":           "esc",
+		"create":         "ctrl+n",
+		"delete":         "ctrl+d",
+		"reboot":         "ctrl+o",
+		"hard_reboot":    "ctrl+p",
+		"refresh":        "R",
+		"up":             "up,k",
+		"down":           "down,j",
+		"left":           "left,h",
+		"right":          "right,l",
+		"tab":            "tab",
+		"shift_tab":      "shift+tab",
+		"pause":          "p",
+		"suspend":        "ctrl+z",
+		"shelve":         "ctrl+e",
+		"resize":         "ctrl+f",
+		"confirm_resize": "ctrl+y",
+		"revert_resize":  "ctrl+x",
+		"actions":        "a",
+		"console":        "L",
+		"select":         "space",
+		"confirm":        "y",
+		"deny":           "n",
+		"restart":        "ctrl+r",
+		"attach":         "ctrl+a",
+		"detach":         "ctrl+t",
+		"allocate":       "ctrl+n",
+		"page_up":        "pgup",
+		"page_down":      "pgdown",
+		"sort":           "s",
+		"reverse_sort":   "S",
+		"project_pick":   "P",
+		"quota":          "Q",
+		"stop_start":     "o",
+		"lock":           "ctrl+l",
+		"rename":         "r",
+		"rebuild":        "ctrl+g",
+		"snapshot":       "ctrl+s",
+		"deactivate":     "d",
+		"rescue":         "ctrl+w",
+		"clone":          "c",
+		"jump_volumes":   "v",
+		"jump_sec_groups": "g",
+		"jump_networks":  "N",
+		"ssh":            "x",
+		"copy_ssh":       "y",
+		"console_url":    "V",
+		"config":         "ctrl+k",
+	}
+}
+
+// Load reads config from DefaultPath. Returns Defaults() if file does not exist.
+func Load() (Config, error) {
+	return LoadFrom(DefaultPath())
+}
+
+// rawGeneral mirrors GeneralConfig with pointer bools to detect presence in YAML.
+type rawGeneral struct {
+	RefreshInterval int   `yaml:"refresh_interval"`
+	IdleTimeout     int   `yaml:"idle_timeout"`
+	PlainMode       *bool `yaml:"plain_mode"`
+	CheckForUpdates *bool `yaml:"check_for_updates"`
+	AlwaysPickCloud *bool `yaml:"always_pick_cloud"`
+}
+
+type rawConfig struct {
+	General     rawGeneral        `yaml:"general"`
+	Colors      ColorConfig       `yaml:"colors"`
+	Keybindings map[string]string `yaml:"keybindings,omitempty"`
+}
+
+// LoadFrom reads config from the given path.
+func LoadFrom(path string) (Config, error) {
+	defaults := Defaults()
+	if path == "" {
+		return defaults, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return defaults, nil
+		}
+		return defaults, err
+	}
+
+	var raw rawConfig
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return defaults, err
+	}
+
+	file := Config{
+		General: GeneralConfig{
+			RefreshInterval: raw.General.RefreshInterval,
+			IdleTimeout:     raw.General.IdleTimeout,
+		},
+		Colors:      raw.Colors,
+		Keybindings: raw.Keybindings,
+	}
+
+	// Use raw pointer bools to distinguish "explicitly false" from "absent".
+	if raw.General.PlainMode != nil {
+		file.General.PlainMode = *raw.General.PlainMode
+	} else {
+		file.General.PlainMode = defaults.General.PlainMode
+	}
+	if raw.General.CheckForUpdates != nil {
+		file.General.CheckForUpdates = *raw.General.CheckForUpdates
+	} else {
+		file.General.CheckForUpdates = defaults.General.CheckForUpdates
+	}
+	if raw.General.AlwaysPickCloud != nil {
+		file.General.AlwaysPickCloud = *raw.General.AlwaysPickCloud
+	} else {
+		file.General.AlwaysPickCloud = defaults.General.AlwaysPickCloud
+	}
+
+	return mergeWithDefaults(file, defaults), nil
+}
+
+// mergeWithDefaults fills zero-valued fields in file with defaults.
+// Bool fields are handled in LoadFrom via rawGeneral pointer detection.
+func mergeWithDefaults(file, defaults Config) Config {
+	if file.General.RefreshInterval == 0 {
+		file.General.RefreshInterval = defaults.General.RefreshInterval
+	}
+
+	if file.Colors.Primary == "" {
+		file.Colors.Primary = defaults.Colors.Primary
+	}
+	if file.Colors.Secondary == "" {
+		file.Colors.Secondary = defaults.Colors.Secondary
+	}
+	if file.Colors.Success == "" {
+		file.Colors.Success = defaults.Colors.Success
+	}
+	if file.Colors.Warning == "" {
+		file.Colors.Warning = defaults.Colors.Warning
+	}
+	if file.Colors.Error == "" {
+		file.Colors.Error = defaults.Colors.Error
+	}
+	if file.Colors.Muted == "" {
+		file.Colors.Muted = defaults.Colors.Muted
+	}
+	if file.Colors.Bg == "" {
+		file.Colors.Bg = defaults.Colors.Bg
+	}
+	if file.Colors.Fg == "" {
+		file.Colors.Fg = defaults.Colors.Fg
+	}
+	if file.Colors.Highlight == "" {
+		file.Colors.Highlight = defaults.Colors.Highlight
+	}
+	if file.Colors.Cyan == "" {
+		file.Colors.Cyan = defaults.Colors.Cyan
+	}
+
+	if file.Keybindings == nil {
+		file.Keybindings = defaults.Keybindings
+	} else {
+		for k, v := range defaults.Keybindings {
+			if _, ok := file.Keybindings[k]; !ok {
+				file.Keybindings[k] = v
+			}
+		}
+	}
+
+	return file
+}
+
+// Merge applies CLI flag overrides on top of file config.
+// CLI flags take precedence when explicitly set (non-nil pointers).
+func Merge(file Config, flags CLIFlags) Config {
+	if flags.RefreshInterval != nil {
+		file.General.RefreshInterval = int(flags.RefreshInterval.Seconds())
+	}
+	if flags.IdleTimeout != nil {
+		file.General.IdleTimeout = int(flags.IdleTimeout.Minutes())
+	}
+	if flags.PlainMode != nil {
+		file.General.PlainMode = *flags.PlainMode
+	}
+	if flags.CheckForUpdates != nil {
+		file.General.CheckForUpdates = *flags.CheckForUpdates
+	}
+	if flags.AlwaysPickCloud != nil {
+		file.General.AlwaysPickCloud = *flags.AlwaysPickCloud
+	}
+	return file
+}
+
+// Save writes config to DefaultPath, creating directories as needed.
+func (c *Config) Save() error {
+	return c.SaveTo(DefaultPath())
+}
+
+// SaveTo writes config to the given path.
+func (c *Config) SaveTo(path string) error {
+	if path == "" {
+		return errors.New("config: empty path")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(c)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/src/internal/config/config_test.go
+++ b/src/internal/config/config_test.go
@@ -1,0 +1,137 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDefaults(t *testing.T) {
+	d := Defaults()
+	if d.General.RefreshInterval != 5 {
+		t.Errorf("RefreshInterval = %d, want 5", d.General.RefreshInterval)
+	}
+	if d.General.CheckForUpdates != true {
+		t.Error("CheckForUpdates should default to true")
+	}
+	if d.Colors.Primary != "#7D56F4" {
+		t.Errorf("Primary = %s, want #7D56F4", d.Colors.Primary)
+	}
+	if d.Colors.Muted != "#657B83" {
+		t.Errorf("Muted = %s, want #657B83", d.Colors.Muted)
+	}
+	if d.Keybindings["quit"] != "q,ctrl+c" {
+		t.Errorf("quit binding = %s, want q,ctrl+c", d.Keybindings["quit"])
+	}
+	if d.Keybindings["config"] != "ctrl+k" {
+		t.Errorf("config binding = %s, want ctrl+k", d.Keybindings["config"])
+	}
+}
+
+func TestSaveAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	cfg := Defaults()
+	cfg.General.RefreshInterval = 10
+	cfg.Colors.Primary = "#FF0000"
+	cfg.Keybindings["quit"] = "ctrl+q"
+
+	if err := cfg.SaveTo(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.General.RefreshInterval != 10 {
+		t.Errorf("RefreshInterval = %d, want 10", loaded.General.RefreshInterval)
+	}
+	if loaded.Colors.Primary != "#FF0000" {
+		t.Errorf("Primary = %s, want #FF0000", loaded.Colors.Primary)
+	}
+	if loaded.Keybindings["quit"] != "ctrl+q" {
+		t.Errorf("quit = %s, want ctrl+q", loaded.Keybindings["quit"])
+	}
+	// Unmodified defaults should still be present
+	if loaded.Keybindings["help"] != "?" {
+		t.Errorf("help = %s, want ?", loaded.Keybindings["help"])
+	}
+}
+
+func TestLoadMissing(t *testing.T) {
+	cfg, err := LoadFrom("/nonexistent/path/config.yaml")
+	if err != nil {
+		t.Fatalf("Load missing: %v", err)
+	}
+	if cfg.General.RefreshInterval != 5 {
+		t.Errorf("RefreshInterval = %d, want default 5", cfg.General.RefreshInterval)
+	}
+}
+
+func TestMergeCLIFlags(t *testing.T) {
+	cfg := Defaults()
+
+	refresh := 10 * time.Second
+	plain := true
+	flags := CLIFlags{
+		RefreshInterval: &refresh,
+		PlainMode:       &plain,
+	}
+
+	merged := Merge(cfg, flags)
+	if merged.General.RefreshInterval != 10 {
+		t.Errorf("RefreshInterval = %d, want 10", merged.General.RefreshInterval)
+	}
+	if !merged.General.PlainMode {
+		t.Error("PlainMode should be true from CLI flag")
+	}
+	// Unset flags should keep file values
+	if !merged.General.CheckForUpdates {
+		t.Error("CheckForUpdates should remain true (not overridden)")
+	}
+}
+
+func TestMergeWithDefaults(t *testing.T) {
+	// Simulate a partial config file (only general section set)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte("general:\n  refresh_interval: 15\n"), 0o644)
+
+	loaded, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.General.RefreshInterval != 15 {
+		t.Errorf("RefreshInterval = %d, want 15", loaded.General.RefreshInterval)
+	}
+	// Bool defaults should be preserved when absent from file
+	if !loaded.General.CheckForUpdates {
+		t.Error("CheckForUpdates should default to true when absent from config file")
+	}
+	// Colors should be filled from defaults
+	if loaded.Colors.Primary != "#7D56F4" {
+		t.Errorf("Primary = %s, want default #7D56F4", loaded.Colors.Primary)
+	}
+	// Keybindings should be filled from defaults
+	if loaded.Keybindings["quit"] != "q,ctrl+c" {
+		t.Errorf("quit = %s, want default q,ctrl+c", loaded.Keybindings["quit"])
+	}
+}
+
+func TestBoolExplicitFalse(t *testing.T) {
+	// When a bool is explicitly set to false in the file, it should stay false
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte("general:\n  check_for_updates: false\n"), 0o644)
+
+	loaded, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.General.CheckForUpdates {
+		t.Error("CheckForUpdates should be false when explicitly set to false")
+	}
+}

--- a/src/internal/shared/keys.go
+++ b/src/internal/shared/keys.go
@@ -55,6 +55,7 @@ type KeyMap struct {
 	SSH         key.Binding
 	CopySSH     key.Binding
 	ConsoleURL  key.Binding
+	Config       key.Binding
 }
 
 var Keys = KeyMap{
@@ -265,5 +266,9 @@ var Keys = KeyMap{
 	ConsoleURL: key.NewBinding(
 		key.WithKeys("V"),
 		key.WithHelp("V", "console URL (noVNC)"),
+	),
+	Config: key.NewBinding(
+		key.WithKeys("ctrl+k"),
+		key.WithHelp("ctrl+k", "config"),
 	),
 }

--- a/src/internal/shared/messages.go
+++ b/src/internal/shared/messages.go
@@ -118,3 +118,6 @@ type ConsoleURLErrMsg struct {
 	Err        error
 	ServerName string
 }
+
+// ConfigChangedMsg is sent after the config is modified and saved at runtime.
+type ConfigChangedMsg struct{}

--- a/src/internal/shared/styles.go
+++ b/src/internal/shared/styles.go
@@ -171,3 +171,81 @@ var (
 	StyleValue = lipgloss.NewStyle().
 			Foreground(ColorFg)
 )
+
+// RebuildStyles reassigns all Style* vars from current Color* values.
+// Must be called after mutating Color* vars so styles pick up the new colors.
+func RebuildStyles() {
+	StyleTitle = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(ColorPrimary).
+		PaddingLeft(1)
+
+	StyleStatusBar = lipgloss.NewStyle().
+		Background(lipgloss.Color("#073642")).
+		Foreground(ColorFg).
+		PaddingLeft(1).
+		PaddingRight(1)
+
+	StyleStatusBarKey = lipgloss.NewStyle().
+		Background(lipgloss.Color("#073642")).
+		Foreground(ColorPrimary).
+		Bold(true)
+
+	StyleHelp = lipgloss.NewStyle().
+		Foreground(ColorFg)
+
+	StyleModal = lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ColorPrimary).
+		Padding(1, 2)
+
+	StyleModalTitle = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(ColorPrimary).
+		MarginBottom(1)
+
+	StyleErrorModal = lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ColorError).
+		Padding(1, 2)
+
+	StyleSelected = lipgloss.NewStyle().
+		Background(lipgloss.Color("#073642")).
+		Foreground(ColorHighlight)
+
+	StyleHeader = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(ColorSecondary)
+
+	StyleLabel = lipgloss.NewStyle().
+		Foreground(ColorSecondary).
+		Bold(true).
+		Width(20)
+
+	StyleValue = lipgloss.NewStyle().
+		Foreground(ColorFg)
+
+	// Rebuild status/power color maps that reference Color* vars.
+	StatusColors["ACTIVE"] = ColorSuccess
+	StatusColors["BUILD"] = ColorWarning
+	StatusColors["SHUTOFF"] = ColorMuted
+	StatusColors["ERROR"] = ColorError
+	StatusColors["REBOOT"] = ColorCyan
+	StatusColors["HARD_REBOOT"] = ColorCyan
+	StatusColors["RESIZE"] = ColorWarning
+	StatusColors["VERIFY_RESIZE"] = ColorWarning
+	StatusColors["MIGRATING"] = ColorWarning
+	StatusColors["PAUSED"] = ColorMuted
+	StatusColors["SUSPENDED"] = ColorMuted
+	StatusColors["DELETED"] = ColorError
+	StatusColors["SOFT_DELETED"] = ColorError
+	StatusColors["SHELVED"] = ColorMuted
+	StatusColors["SHELVED_OFFLOADED"] = ColorMuted
+
+	PowerColors["RUNNING"] = ColorSuccess
+	PowerColors["PAUSED"] = ColorMuted
+	PowerColors["SHUTDOWN"] = ColorMuted
+	PowerColors["CRASHED"] = ColorError
+	PowerColors["SUSPENDED"] = ColorMuted
+	PowerColors["NOSTATE"] = ColorWarning
+}

--- a/src/internal/ui/configview/configview.go
+++ b/src/internal/ui/configview/configview.go
@@ -1,0 +1,558 @@
+package configview
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/larkly/lazystack/internal/config"
+	"github.com/larkly/lazystack/internal/shared"
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/textinput"
+	"charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+type itemKind int
+
+const (
+	kindBool itemKind = iota
+	kindNumeric
+	kindColor
+	kindKeybinding
+)
+
+type configItem struct {
+	label string
+	key   string
+	kind  itemKind
+	get   func() string
+	set   func(string) error
+}
+
+type category struct {
+	name  string
+	items []configItem
+}
+
+// Model is the config overlay.
+type Model struct {
+	Visible bool
+	Width   int
+	Height  int
+
+	cfg        *config.Config
+	categories []category
+	cursor     int // flat index across all items
+	editing    bool
+	textInput  textinput.Model
+	keyCapture bool
+	errMsg     string
+	scroll     int
+}
+
+// New creates a new config overlay model.
+func New(cfg *config.Config) Model {
+	ti := textinput.New()
+	ti.CharLimit = 32
+	if cfg == nil {
+		defaults := config.Defaults()
+		cfg = &defaults
+	}
+	m := Model{
+		cfg:       cfg,
+		textInput: ti,
+	}
+	m.buildCategories()
+	return m
+}
+
+// Cfg returns the config pointer for reading current values.
+func (m *Model) Cfg() *config.Config {
+	return m.cfg
+}
+
+// Open shows the config overlay.
+func (m *Model) Open() {
+	m.Visible = true
+	m.cursor = 0
+	m.editing = false
+	m.keyCapture = false
+	m.errMsg = ""
+	m.scroll = 0
+	m.buildCategories()
+}
+
+func (m *Model) buildCategories() {
+	cfg := m.cfg
+	m.categories = []category{
+		{
+			name: "General",
+			items: []configItem{
+				{label: "Refresh interval (s)", key: "refresh_interval", kind: kindNumeric,
+					get: func() string { return strconv.Itoa(cfg.General.RefreshInterval) },
+					set: func(v string) error {
+						n, err := strconv.Atoi(v)
+						if err != nil || n < 1 {
+							return fmt.Errorf("must be a positive integer")
+						}
+						cfg.General.RefreshInterval = n
+						return nil
+					},
+				},
+				{label: "Idle timeout (min)", key: "idle_timeout", kind: kindNumeric,
+					get: func() string { return strconv.Itoa(cfg.General.IdleTimeout) },
+					set: func(v string) error {
+						n, err := strconv.Atoi(v)
+						if err != nil || n < 0 {
+							return fmt.Errorf("must be a non-negative integer")
+						}
+						cfg.General.IdleTimeout = n
+						return nil
+					},
+				},
+				{label: "Plain mode", key: "plain_mode", kind: kindBool,
+					get: func() string { return boolStr(cfg.General.PlainMode) },
+					set: func(string) error {
+						cfg.General.PlainMode = !cfg.General.PlainMode
+						return nil
+					},
+				},
+				{label: "Check for updates", key: "check_for_updates", kind: kindBool,
+					get: func() string { return boolStr(cfg.General.CheckForUpdates) },
+					set: func(string) error {
+						cfg.General.CheckForUpdates = !cfg.General.CheckForUpdates
+						return nil
+					},
+				},
+				{label: "Always pick cloud", key: "always_pick_cloud", kind: kindBool,
+					get: func() string { return boolStr(cfg.General.AlwaysPickCloud) },
+					set: func(string) error {
+						cfg.General.AlwaysPickCloud = !cfg.General.AlwaysPickCloud
+						return nil
+					},
+				},
+			},
+		},
+		{
+			name:  "Colors",
+			items: m.buildColorItems(),
+		},
+		{
+			name:  "Keybindings",
+			items: m.buildKeybindingItems(),
+		},
+	}
+}
+
+func (m *Model) buildColorItems() []configItem {
+	cfg := m.cfg
+	type colorField struct {
+		label string
+		get   func() string
+		set   func(string)
+	}
+	fields := []colorField{
+		{"Primary", func() string { return cfg.Colors.Primary }, func(v string) { cfg.Colors.Primary = v }},
+		{"Secondary", func() string { return cfg.Colors.Secondary }, func(v string) { cfg.Colors.Secondary = v }},
+		{"Success", func() string { return cfg.Colors.Success }, func(v string) { cfg.Colors.Success = v }},
+		{"Warning", func() string { return cfg.Colors.Warning }, func(v string) { cfg.Colors.Warning = v }},
+		{"Error", func() string { return cfg.Colors.Error }, func(v string) { cfg.Colors.Error = v }},
+		{"Muted", func() string { return cfg.Colors.Muted }, func(v string) { cfg.Colors.Muted = v }},
+		{"Background", func() string { return cfg.Colors.Bg }, func(v string) { cfg.Colors.Bg = v }},
+		{"Foreground", func() string { return cfg.Colors.Fg }, func(v string) { cfg.Colors.Fg = v }},
+		{"Highlight", func() string { return cfg.Colors.Highlight }, func(v string) { cfg.Colors.Highlight = v }},
+		{"Cyan", func() string { return cfg.Colors.Cyan }, func(v string) { cfg.Colors.Cyan = v }},
+	}
+	items := make([]configItem, len(fields))
+	for i, f := range fields {
+		f := f
+		items[i] = configItem{
+			label: f.label, kind: kindColor,
+			get: f.get,
+			set: func(v string) error {
+				if !isValidHex(v) {
+					return fmt.Errorf("invalid hex color")
+				}
+				f.set(v)
+				return nil
+			},
+		}
+	}
+	return items
+}
+
+var reservedKeys = map[string]bool{
+	"ctrl+a": true,
+	"ctrl+b": true,
+}
+
+func (m *Model) buildKeybindingItems() []configItem {
+	cfg := m.cfg
+	// Use a stable order matching DefaultKeybindings
+	order := keybindingOrder()
+	var items []configItem
+	for _, name := range order {
+		name := name
+		if _, ok := cfg.Keybindings[name]; !ok {
+			continue
+		}
+		items = append(items, configItem{
+			label: keybindingLabel(name), key: name, kind: kindKeybinding,
+			get: func() string { return cfg.Keybindings[name] },
+			set: func(v string) error {
+				if reservedKeys[v] {
+					return fmt.Errorf("reserved key (%s)", v)
+				}
+				cfg.Keybindings[name] = v
+				return nil
+			},
+		})
+	}
+	return items
+}
+
+// Update handles messages for the config overlay.
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if m.keyCapture {
+			return m.handleKeyCapture(msg)
+		}
+		if m.editing {
+			return m.handleEditing(msg)
+		}
+		return m.handleBrowsing(msg)
+
+	case tea.WindowSizeMsg:
+		m.Width = msg.Width
+		m.Height = msg.Height
+	}
+	return m, nil
+}
+
+func (m Model) handleBrowsing(msg tea.KeyMsg) (Model, tea.Cmd) {
+	m.errMsg = ""
+	total := m.totalItems()
+
+	switch {
+	case key.Matches(msg, shared.Keys.Back):
+		m.Visible = false
+		return m, nil
+
+	case key.Matches(msg, shared.Keys.Down):
+		if m.cursor < total-1 {
+			m.cursor++
+			m.ensureVisible()
+		}
+
+	case key.Matches(msg, shared.Keys.Up):
+		if m.cursor > 0 {
+			m.cursor--
+			m.ensureVisible()
+		}
+
+	case key.Matches(msg, shared.Keys.PageDown):
+		m.cursor += m.viewHeight()
+		if m.cursor >= total {
+			m.cursor = total - 1
+		}
+		m.ensureVisible()
+
+	case key.Matches(msg, shared.Keys.PageUp):
+		m.cursor -= m.viewHeight()
+		if m.cursor < 0 {
+			m.cursor = 0
+		}
+		m.ensureVisible()
+
+	case key.Matches(msg, shared.Keys.Enter), key.Matches(msg, shared.Keys.Select):
+		item := m.currentItem()
+		if item == nil {
+			break
+		}
+		switch item.kind {
+		case kindBool:
+			if err := item.set(""); err != nil {
+				m.errMsg = err.Error()
+			} else {
+				return m, m.applyAndSave()
+			}
+		case kindNumeric, kindColor:
+			m.editing = true
+			m.textInput.SetValue(item.get())
+			m.textInput.Focus()
+		case kindKeybinding:
+			m.keyCapture = true
+			m.errMsg = ""
+		}
+	}
+
+	return m, nil
+}
+
+func (m Model) handleEditing(msg tea.KeyMsg) (Model, tea.Cmd) {
+	switch {
+	case key.Matches(msg, shared.Keys.Back):
+		m.editing = false
+		m.errMsg = ""
+		return m, nil
+
+	case key.Matches(msg, shared.Keys.Enter):
+		item := m.currentItem()
+		if item == nil {
+			m.editing = false
+			return m, nil
+		}
+		val := m.textInput.Value()
+		if err := item.set(val); err != nil {
+			m.errMsg = err.Error()
+			return m, nil
+		}
+		m.editing = false
+		m.errMsg = ""
+		return m, m.applyAndSave()
+
+	default:
+		var cmd tea.Cmd
+		m.textInput, cmd = m.textInput.Update(msg)
+		return m, cmd
+	}
+}
+
+func (m Model) handleKeyCapture(msg tea.KeyMsg) (Model, tea.Cmd) {
+	keyStr := msg.String()
+
+	if key.Matches(msg, shared.Keys.Back) {
+		m.keyCapture = false
+		m.errMsg = ""
+		return m, nil
+	}
+
+	if reservedKeys[keyStr] {
+		m.errMsg = fmt.Sprintf("reserved key (%s)", keyStr)
+		return m, nil
+	}
+
+	item := m.currentItem()
+	if item == nil {
+		m.keyCapture = false
+		return m, nil
+	}
+
+	if err := item.set(keyStr); err != nil {
+		m.errMsg = err.Error()
+		return m, nil
+	}
+	m.keyCapture = false
+	m.errMsg = ""
+	return m, m.applyAndSave()
+}
+
+func (m *Model) applyAndSave() tea.Cmd {
+	config.ApplyAll(*m.cfg)
+	if err := m.cfg.Save(); err != nil {
+		m.errMsg = "save failed: " + err.Error()
+	}
+	return func() tea.Msg { return shared.ConfigChangedMsg{} }
+}
+
+func (m Model) currentItem() *configItem {
+	idx := 0
+	for ci := range m.categories {
+		for ii := range m.categories[ci].items {
+			if idx == m.cursor {
+				return &m.categories[ci].items[ii]
+			}
+			idx++
+		}
+	}
+	return nil
+}
+
+func (m Model) totalItems() int {
+	n := 0
+	for _, c := range m.categories {
+		n += len(c.items)
+	}
+	return n
+}
+
+func (m Model) viewHeight() int {
+	h := m.Height - 8
+	if h < 5 {
+		h = 5
+	}
+	return h
+}
+
+func (m *Model) ensureVisible() {
+	// Each category header + items; compute line index for cursor
+	line := m.cursorLine()
+	vh := m.viewHeight()
+	if line < m.scroll {
+		m.scroll = line
+	}
+	if line >= m.scroll+vh {
+		m.scroll = line - vh + 1
+	}
+}
+
+func (m Model) cursorLine() int {
+	line := 0
+	idx := 0
+	for _, c := range m.categories {
+		line++ // category header
+		for range c.items {
+			if idx == m.cursor {
+				return line
+			}
+			line++
+			idx++
+		}
+		line++ // blank line after category
+	}
+	return line
+}
+
+// Render returns the config overlay content.
+func (m Model) Render() string {
+	title := shared.StyleModalTitle.Render("Configuration")
+
+	lines := m.buildLines()
+
+	vh := m.viewHeight()
+	start := m.scroll
+	if start > len(lines) {
+		start = len(lines)
+	}
+	end := start + vh
+	if end > len(lines) {
+		end = len(lines)
+	}
+
+	visible := strings.Join(lines[start:end], "\n")
+
+	errLine := ""
+	if m.errMsg != "" {
+		errLine = "\n" + lipgloss.NewStyle().Foreground(shared.ColorError).Render("  "+m.errMsg)
+	}
+
+	scrollHint := ""
+	if m.scroll > 0 || end < len(lines) {
+		scrollHint = shared.StyleHelp.Render(" ↑↓ scroll •")
+	}
+
+	hint := scrollHint + shared.StyleHelp.Render(" esc close")
+	if m.editing {
+		hint = shared.StyleHelp.Render(" enter confirm • esc cancel")
+	} else if m.keyCapture {
+		hint = shared.StyleHelp.Render(" press key to bind • esc cancel")
+	}
+
+	content := title + "\n\n" + visible + errLine + "\n\n" + hint
+	box := shared.StyleModal.Width(58).Render(content)
+
+	return lipgloss.Place(m.Width, m.Height, lipgloss.Center, lipgloss.Center, box)
+}
+
+func (m Model) buildLines() []string {
+	var lines []string
+	idx := 0
+	labelStyle := lipgloss.NewStyle().Foreground(shared.ColorFg).Width(24)
+	selectedStyle := lipgloss.NewStyle().Background(lipgloss.Color("#073642")).Foreground(shared.ColorHighlight)
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(shared.ColorSecondary)
+
+	for _, c := range m.categories {
+		lines = append(lines, headerStyle.Render("  "+c.name))
+		for _, item := range c.items {
+			selected := idx == m.cursor
+			val := item.get()
+
+			var line string
+			switch item.kind {
+			case kindBool:
+				check := "[ ]"
+				if val == "true" {
+					check = "[x]"
+				}
+				line = "    " + labelStyle.Render(item.label) + check
+
+			case kindNumeric:
+				if selected && m.editing {
+					line = "    " + labelStyle.Render(item.label) + m.textInput.View()
+				} else {
+					line = "    " + labelStyle.Render(item.label) + val
+				}
+
+			case kindColor:
+				if selected && m.editing {
+					line = "    " + labelStyle.Render(item.label) + m.textInput.View()
+				} else {
+					swatch := lipgloss.NewStyle().Foreground(lipgloss.Color(val)).Render("████")
+					line = "    " + labelStyle.Render(item.label) + val + "  " + swatch
+				}
+
+			case kindKeybinding:
+				if selected && m.keyCapture {
+					line = "    " + labelStyle.Render(item.label) +
+						lipgloss.NewStyle().Foreground(shared.ColorWarning).Render("Press key...")
+				} else {
+					line = "    " + labelStyle.Render(item.label) + val
+				}
+			}
+
+			if selected && !m.editing && !m.keyCapture {
+				line = selectedStyle.Render(line)
+			}
+			lines = append(lines, line)
+			idx++
+		}
+		lines = append(lines, "")
+	}
+	return lines
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+var hexColorRe = regexp.MustCompile(`^#[0-9a-fA-F]{6}$`)
+
+func isValidHex(s string) bool {
+	return hexColorRe.MatchString(s)
+}
+
+// keybindingOrder returns the display order for keybinding items.
+func keybindingOrder() []string {
+	return []string{
+		"quit", "help", "config", "cloud_pick", "project_pick",
+		"filter", "enter", "back",
+		"up", "down", "left", "right", "page_up", "page_down",
+		"tab", "shift_tab",
+		"create", "delete", "rename", "clone",
+		"reboot", "hard_reboot", "pause", "suspend", "shelve",
+		"stop_start", "lock", "rescue",
+		"resize", "confirm_resize", "revert_resize", "rebuild", "snapshot",
+		"refresh", "actions", "console", "select", "confirm", "deny", "restart",
+		"attach", "detach", "allocate",
+		"sort", "reverse_sort", "deactivate", "quota",
+		"ssh", "copy_ssh", "console_url",
+		"jump_volumes", "jump_sec_groups", "jump_networks",
+	}
+}
+
+// keybindingLabel converts a snake_case config key to a display label.
+func keybindingLabel(name string) string {
+	parts := strings.Split(name, "_")
+	for i, p := range parts {
+		if len(p) > 0 {
+			parts[i] = strings.ToUpper(p[:1]) + p[1:]
+		}
+	}
+	return strings.Join(parts, " ")
+}

--- a/src/internal/ui/help/help.go
+++ b/src/internal/ui/help/help.go
@@ -49,6 +49,7 @@ var allSections = []section{
 			"R             force refresh",
 			"pgup/pgdn    page up/down",
 			"s/S           sort / reverse sort",
+			"ctrl+k       configuration",
 			"ctrl+r       restart app",
 		},
 	},


### PR DESCRIPTION
## Summary
- Add `~/.config/lazystack/config.yaml` for persisting settings (general, colors, keybindings) across sessions
- Add runtime config overlay (`ctrl+k`) with category navigation, boolean toggles, numeric/color inputs, and key capture mode for rebinding keys
- CLI flags take precedence over config file values; changes take effect immediately and persist to disk

## Test plan
- [ ] Launch without config file — runs with defaults, no errors
- [ ] Open config view (`ctrl+k`) — categories and values display correctly
- [ ] Toggle a boolean (plain mode) — takes effect immediately, persists to `~/.config/lazystack/config.yaml`
- [ ] Change a color — UI re-renders with new color
- [ ] Rebind a key — new binding works
- [ ] Verify `ctrl+a`/`ctrl+b` are rejected when rebinding
- [ ] Restart app — config persists
- [ ] Pass `--refresh 10` — overrides config file value
- [ ] `go test ./internal/config/...` passes