### PR TITLE
fix: address code review findings from v0.4.0 audit

### DIFF
--- a/src/internal/app/actions_server.go
+++ b/src/internal/app/actions_server.go
@@ -545,9 +545,12 @@ func (m Model) executeAction(action modal.ConfirmAction) (Model, tea.Cmd) {
 		volIDs := action.VolumeIDs
 		return m, func() tea.Msg {
 			// Detach volumes before deleting the server
+			var volErrs []string
 			if deleteVols && bsClient != nil {
 				for _, vid := range volIDs {
-					_ = volume.DetachVolume(context.Background(), computeC, action.ServerID, vid)
+					if err := volume.DetachVolume(context.Background(), computeC, action.ServerID, vid); err != nil {
+						volErrs = append(volErrs, fmt.Sprintf("detach %s: %v", vid, err))
+					}
 				}
 				// Wait for volumes to detach (up to 30s)
 				for range 10 {
@@ -573,10 +576,16 @@ func (m Model) executeAction(action modal.ConfirmAction) (Model, tea.Cmd) {
 
 			if deleteVols && bsClient != nil {
 				for _, vid := range volIDs {
-					volume.DeleteVolume(context.Background(), bsClient, vid)
+					if err := volume.DeleteVolume(context.Background(), bsClient, vid); err != nil {
+						volErrs = append(volErrs, fmt.Sprintf("delete %s: %v", vid, err))
+					}
 				}
 			}
-			return shared.ServerActionMsg{Action: "Delete", Name: action.Name}
+			msg := shared.ServerActionMsg{Action: "Delete", Name: action.Name}
+			if len(volErrs) > 0 {
+				msg.Action = fmt.Sprintf("Delete (warning: %d volume error(s))", len(volErrs))
+			}
+			return msg
 		}
 	case "soft reboot":
 		return m, func() tea.Msg {
@@ -859,6 +868,7 @@ func (m Model) executeBulkAction(client *gophercloud.ServiceClient, action modal
 	act := action.Action
 	return func() tea.Msg {
 		var errs []string
+		var passwords []string
 		for _, s := range targets {
 			var err error
 			switch act {
@@ -887,7 +897,11 @@ func (m Model) executeBulkAction(client *gophercloud.ServiceClient, action modal
 			case "unlock":
 				err = compute.UnlockServer(context.Background(), client, s.ID)
 			case "rescue":
-				_, err = compute.RescueServer(context.Background(), client, s.ID)
+				var adminPass string
+				adminPass, err = compute.RescueServer(context.Background(), client, s.ID)
+				if err == nil && adminPass != "" {
+					passwords = append(passwords, fmt.Sprintf("%s: %s", s.Name, adminPass))
+				}
 			case "unrescue":
 				err = compute.UnrescueServer(context.Background(), client, s.ID)
 			}
@@ -902,10 +916,14 @@ func (m Model) executeBulkAction(client *gophercloud.ServiceClient, action modal
 				Err:    fmt.Errorf("%s", strings.Join(errs, "; ")),
 			}
 		}
-		return shared.ServerActionMsg{
+		msg := shared.ServerActionMsg{
 			Action: act,
 			Name:   fmt.Sprintf("%d servers", len(targets)),
 		}
+		if len(passwords) > 0 {
+			msg.Action = fmt.Sprintf("Rescue (passwords: %s)", strings.Join(passwords, ", "))
+		}
+		return msg
 	}
 }
 

--- a/src/internal/app/app.go
+++ b/src/internal/app/app.go
@@ -984,6 +984,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.serverResize.Active = false
 		// Navigate back to server list if on a sub-view, or after delete
 		if m.view == viewConsoleLog || (m.view == viewServerDetail && msg.Action == "Delete") {
+			m.returnToView = 0
 			m.view = viewServerList
 			m.statusBar.CurrentView = "serverlist"
 			return m, func() tea.Msg { return shared.RefreshServersMsg{} }
@@ -1012,6 +1013,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.statusBar.StickyHint = fmt.Sprintf("✓ %s %s", msg.Action, msg.Name)
 		m.statusBar.Error = ""
 		// Navigate back to list view if we were on a detail view
+		m.returnToView = 0
 		if m.view == viewVolumeDetail {
 			m.view = viewVolumeList
 			m.statusBar.CurrentView = "volumelist"

--- a/src/internal/shared/format.go
+++ b/src/internal/shared/format.go
@@ -1,0 +1,25 @@
+package shared
+
+import "fmt"
+
+// FormatSize formats a byte count as a human-readable size string.
+func FormatSize(bytes int64) string {
+	if bytes == 0 {
+		return "-"
+	}
+	const (
+		kb = 1024
+		mb = 1024 * kb
+		gb = 1024 * mb
+	)
+	switch {
+	case bytes >= gb:
+		return fmt.Sprintf("%.1f GB", float64(bytes)/float64(gb))
+	case bytes >= mb:
+		return fmt.Sprintf("%.1f MB", float64(bytes)/float64(mb))
+	case bytes >= kb:
+		return fmt.Sprintf("%.0f KB", float64(bytes)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
+}

--- a/src/internal/ui/cloneprogress/cloneprogress.go
+++ b/src/internal/ui/cloneprogress/cloneprogress.go
@@ -17,6 +17,8 @@ import (
 	bsvolumes "github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes"
 )
 
+const pollInterval = 3 * time.Second
+
 // VolumeOp tracks the state of a single volume clone+attach operation.
 type VolumeOp struct {
 	SourceVolID string
@@ -255,7 +257,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			return m, tea.Batch(cmds...)
 		}
 		// Not ready yet — poll again
-		return m, tea.Tick(3*time.Second, func(time.Time) tea.Msg {
+		return m, tea.Tick(pollInterval, func(time.Time) tea.Msg {
 			return pollTickMsg{}
 		})
 
@@ -370,7 +372,7 @@ func (m Model) createVolume(idx int, op VolumeOp) tea.Cmd {
 }
 
 func (m Model) schedulePoll() tea.Cmd {
-	return tea.Tick(3*time.Second, func(time.Time) tea.Msg {
+	return tea.Tick(pollInterval, func(time.Time) tea.Msg {
 		return pollTickMsg{}
 	})
 }

--- a/src/internal/ui/imagedetail/imagedetail.go
+++ b/src/internal/ui/imagedetail/imagedetail.go
@@ -167,7 +167,7 @@ func (m Model) View() string {
 		{"ID", img.ID},
 		{"Status", img.Status},
 		{"Visibility", img.Visibility},
-		{"Size", formatSize(img.Size)},
+		{"Size", shared.FormatSize(img.Size)},
 		{"Disk Format", img.DiskFormat},
 		{"Container Format", img.ContainerFormat},
 		{"Min Disk", fmt.Sprintf("%d GB", img.MinDisk)},
@@ -231,29 +231,13 @@ func statusStyle(status string) lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(fg)
 }
 
-func formatSize(bytes int64) string {
-	if bytes == 0 {
-		return "-"
-	}
-	const (
-		kb = 1024
-		mb = 1024 * kb
-		gb = 1024 * mb
-	)
-	switch {
-	case bytes >= gb:
-		return fmt.Sprintf("%.1f GB", float64(bytes)/float64(gb))
-	case bytes >= mb:
-		return fmt.Sprintf("%.1f MB", float64(bytes)/float64(mb))
-	case bytes >= kb:
-		return fmt.Sprintf("%.0f KB", float64(bytes)/float64(kb))
-	default:
-		return fmt.Sprintf("%d B", bytes)
-	}
-}
-
 func (m Model) fetchImage() tea.Cmd {
 	client := m.client
+	if client == nil {
+		return func() tea.Msg {
+			return imageDetailErrMsg{err: fmt.Errorf("image service not available")}
+		}
+	}
 	id := m.imageID
 	return func() tea.Msg {
 		img, err := image.GetImage(context.Background(), client, id)

--- a/src/internal/ui/imagelist/imagelist.go
+++ b/src/internal/ui/imagelist/imagelist.go
@@ -439,7 +439,7 @@ func (m Model) View() string {
 		values := map[string]string{
 			"name":       name,
 			"status":     shared.StatusIcon(img.Status) + img.Status,
-			"size":       formatSize(img.Size),
+			"size":       shared.FormatSize(img.Size),
 			"min_disk":   fmt.Sprintf("%dGB", img.MinDisk),
 			"min_ram":    fmt.Sprintf("%dMB", img.MinRAM),
 			"visibility": img.Visibility,
@@ -533,27 +533,6 @@ func imageStatusStyle(status string) lipgloss.Style {
 		fg = shared.ColorMuted
 	}
 	return lipgloss.NewStyle().Foreground(fg)
-}
-
-func formatSize(bytes int64) string {
-	if bytes == 0 {
-		return "-"
-	}
-	const (
-		kb = 1024
-		mb = 1024 * kb
-		gb = 1024 * mb
-	)
-	switch {
-	case bytes >= gb:
-		return fmt.Sprintf("%.1fGB", float64(bytes)/float64(gb))
-	case bytes >= mb:
-		return fmt.Sprintf("%.1fMB", float64(bytes)/float64(mb))
-	case bytes >= kb:
-		return fmt.Sprintf("%.0fKB", float64(bytes)/float64(kb))
-	default:
-		return fmt.Sprintf("%dB", bytes)
-	}
 }
 
 func (m Model) fetchImages() tea.Cmd {

--- a/src/internal/ui/modal/confirm_test.go
+++ b/src/internal/ui/modal/confirm_test.go
@@ -161,6 +161,76 @@ func TestEnter_FocusedCancel(t *testing.T) {
 	}
 }
 
+func TestDeleteVolumes_SpaceToggle(t *testing.T) {
+	m := NewConfirm("delete", "srv-1", "web-1")
+	m.VolumeIDs = []string{"vol-1", "vol-2"}
+
+	if m.deleteVolumes {
+		t.Error("deleteVolumes should start false")
+	}
+
+	// Space toggles on
+	m, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: ' ', Text: " "}))
+	if !m.deleteVolumes {
+		t.Error("deleteVolumes should be true after space")
+	}
+
+	// Space toggles off
+	m, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: ' ', Text: " "}))
+	if m.deleteVolumes {
+		t.Error("deleteVolumes should be false after second space")
+	}
+}
+
+func TestDeleteVolumes_NoVolumes_SpaceIgnored(t *testing.T) {
+	m := NewConfirm("delete", "srv-1", "web-1")
+	// No VolumeIDs set
+
+	m, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: ' ', Text: " "}))
+	if m.deleteVolumes {
+		t.Error("deleteVolumes should remain false when no VolumeIDs")
+	}
+}
+
+func TestDeleteVolumes_ConfirmIncludesVolumeIDs(t *testing.T) {
+	m := NewConfirm("delete", "srv-1", "web-1")
+	m.VolumeIDs = []string{"vol-1", "vol-2"}
+
+	// Toggle on
+	m, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: ' ', Text: " "}))
+
+	// Confirm
+	_, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: 'y', Text: "y"}))
+	if cmd == nil {
+		t.Fatal("expected cmd from confirm")
+	}
+	action, ok := cmd().(ConfirmAction)
+	if !ok {
+		t.Fatalf("expected ConfirmAction, got %T", cmd())
+	}
+	if !action.DeleteVolumes {
+		t.Error("expected DeleteVolumes = true")
+	}
+	if len(action.VolumeIDs) != 2 {
+		t.Errorf("VolumeIDs len = %d, want 2", len(action.VolumeIDs))
+	}
+}
+
+func TestDeleteVolumes_ConfirmWithoutToggle(t *testing.T) {
+	m := NewConfirm("delete", "srv-1", "web-1")
+	m.VolumeIDs = []string{"vol-1"}
+
+	// Confirm without toggling space
+	_, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: 'y', Text: "y"}))
+	if cmd == nil {
+		t.Fatal("expected cmd from confirm")
+	}
+	action := cmd().(ConfirmAction)
+	if action.DeleteVolumes {
+		t.Error("expected DeleteVolumes = false when not toggled")
+	}
+}
+
 func TestConfirm_WindowSize(t *testing.T) {
 	m := NewConfirm("delete", "srv-1", "web-1")
 

--- a/src/internal/ui/serverrebuild/serverrebuild.go
+++ b/src/internal/ui/serverrebuild/serverrebuild.go
@@ -159,7 +159,11 @@ func (m Model) updateNormal(msg tea.KeyMsg) (Model, tea.Cmd) {
 func (m Model) updateConfirm(msg tea.KeyMsg) (Model, tea.Cmd) {
 	switch {
 	case key.Matches(msg, shared.Keys.Confirm):
-		return m.doRebuild(m.filtered[m.cursor])
+		if m.cursor >= 0 && m.cursor < len(m.filtered) {
+			return m.doRebuild(m.filtered[m.cursor])
+		}
+		m.confirming = false
+		return m, nil
 	case key.Matches(msg, shared.Keys.Deny), key.Matches(msg, shared.Keys.Back):
 		m.confirming = false
 		m.confirmImage = ""


### PR DESCRIPTION
## Summary

- **Fix silent volume errors**: Detach and delete errors are now collected and reported in the status message instead of being silently discarded
- **Fix bulk rescue passwords**: Admin passwords from bulk rescue operations are captured and displayed in the success message
- **Extract shared FormatSize**: Deduplicated `formatSize` from imagedetail/imagelist into `shared.FormatSize` with consistent space-separated formatting
- **Add bounds check**: Defensive guard in serverrebuild confirm path to prevent potential out-of-bounds panic
- **Add nil client check**: Guard in imagedetail `fetchImage()` matching the existing pattern in imagelist
- **Add volume checkbox tests**: 4 new tests covering space toggle, confirm with/without volumes
- **Extract poll constant**: Named `pollInterval` in cloneprogress replaces hardcoded `3*time.Second`
- **Fix returnToView cleanup**: Clear cross-resource navigation state on server delete and resource action transitions

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (including 4 new confirm modal tests)
- [x] `go vet ./...` clean