### PR TITLE
fix: block mutating actions on locked servers client-side

### DIFF
--- a/src/internal/app/actions_server.go
+++ b/src/internal/app/actions_server.go
@@ -29,6 +29,26 @@ import (
 	"charm.land/bubbletea/v2"
 )
 
+func (m Model) isSelectedServerLocked() bool {
+	if m.view == viewServerList && m.serverList.SelectionCount() > 0 {
+		for _, s := range m.serverList.SelectedServers() {
+			if s.Locked {
+				return true
+			}
+		}
+		return false
+	}
+	switch m.view {
+	case viewServerList:
+		if s := m.serverList.SelectedServer(); s != nil {
+			return s.Locked
+		}
+	case viewServerDetail:
+		return m.serverDetail.ServerLocked()
+	}
+	return false
+}
+
 func (m Model) openClone() (Model, tea.Cmd) {
 	var srv *compute.Server
 	switch m.view {

--- a/src/internal/app/app.go
+++ b/src/internal/app/app.go
@@ -537,6 +537,36 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		if m.view == viewServerList || m.view == viewServerDetail {
+			// Allow read-only actions and lock/unlock regardless of lock state
+			if key.Matches(msg, shared.Keys.Lock) {
+				return m.openToggleConfirm("lock/unlock")
+			}
+			if key.Matches(msg, shared.Keys.CopySSH) {
+				return m.copySSHCommand()
+			}
+			if key.Matches(msg, shared.Keys.ConsoleURL) {
+				return m.openConsoleURL()
+			}
+			if key.Matches(msg, shared.Keys.Console) {
+				return m.openConsoleLog()
+			}
+			if key.Matches(msg, shared.Keys.Actions) {
+				return m.openActionLog()
+			}
+
+			// Block all mutating actions on locked servers
+			if m.isSelectedServerLocked() && key.Matches(msg,
+				shared.Keys.Delete, shared.Keys.Reboot, shared.Keys.HardReboot,
+				shared.Keys.Pause, shared.Keys.Suspend, shared.Keys.Shelve,
+				shared.Keys.StopStart, shared.Keys.Rescue, shared.Keys.SSH,
+				shared.Keys.Resize, shared.Keys.Rename, shared.Keys.Rebuild,
+				shared.Keys.Snapshot, shared.Keys.ConfirmResize, shared.Keys.RevertResize,
+				shared.Keys.Attach, shared.Keys.Clone,
+			) {
+				m.statusBar.StickyHint = "Server is locked. Unlock it first with Ctrl+L."
+				return m, nil
+			}
+
 			if key.Matches(msg, shared.Keys.Delete) {
 				return m.openDeleteConfirm()
 			}
@@ -558,26 +588,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if key.Matches(msg, shared.Keys.StopStart) {
 				return m.openToggleConfirm("stop/start")
 			}
-			if key.Matches(msg, shared.Keys.Lock) {
-				return m.openToggleConfirm("lock/unlock")
-			}
 			if key.Matches(msg, shared.Keys.Rescue) {
 				return m.openToggleConfirm("rescue/unrescue")
 			}
 			if key.Matches(msg, shared.Keys.SSH) {
 				return m.openSSH()
-			}
-			if key.Matches(msg, shared.Keys.CopySSH) {
-				return m.copySSHCommand()
-			}
-			if key.Matches(msg, shared.Keys.ConsoleURL) {
-				return m.openConsoleURL()
-			}
-			if key.Matches(msg, shared.Keys.Console) {
-				return m.openConsoleLog()
-			}
-			if key.Matches(msg, shared.Keys.Actions) {
-				return m.openActionLog()
 			}
 			if key.Matches(msg, shared.Keys.Resize) {
 				return m.openResize()


### PR DESCRIPTION
## Summary
- Pre-check server lock status before dispatching any mutating action (delete, reboot, resize, rename, etc.)
- Show a clear sticky hint ("Server is locked. Unlock it first with Ctrl+L.") instead of letting the API reject with a confusing error
- Read-only actions (console log, console URL, action history, copy SSH) and lock/unlock itself remain unguarded

Closes #55

## Test plan
- [ ] Select a locked server, press any mutating key (e.g., Ctrl+D for delete) — verify sticky hint appears and no confirmation modal opens
- [ ] Select a locked server, press Ctrl+L — verify lock/unlock toggle still works
- [ ] Select a locked server, press read-only keys (L, a, V, y) — verify they still work
- [ ] Bulk-select servers including a locked one, press a mutating key — verify it's blocked
- [ ] Select an unlocked server, press mutating keys — verify normal behavior unchanged