### PR TITLE
feat: passive update-available indicator

### DIFF
--- a/src/cmd/lazystack/main.go
+++ b/src/cmd/lazystack/main.go
@@ -17,6 +17,7 @@ import (
 )
 
 var version = "dev"
+var noUpdate = "false"
 
 func main() {
 	showVersion := flag.Bool("version", false, "print version and exit")
@@ -34,7 +35,14 @@ func main() {
 		return
 	}
 
+	noUpdateBuild := noUpdate == "true" || noUpdate == "1"
+
 	if *doUpdate {
+		if noUpdateBuild {
+			fmt.Fprintln(os.Stderr, "This build of lazystack is managed by your system package manager.")
+			fmt.Fprintln(os.Stderr, "Use your package manager to update (e.g., pacman -Syu, apt upgrade, dnf upgrade).")
+			os.Exit(1)
+		}
 		latest, downloadURL, checksumsURL, err := selfupdate.CheckLatest(version)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -101,6 +109,7 @@ func main() {
 		IdleTimeout:     time.Duration(cfg.General.IdleTimeout) * time.Minute,
 		Version:         version,
 		CheckUpdate:     cfg.General.CheckForUpdates,
+		NoUpdateBuild:   noUpdateBuild,
 		Plain:           cfg.General.PlainMode,
 		Config:          &cfg,
 	})

--- a/src/internal/app/app.go
+++ b/src/internal/app/app.go
@@ -182,9 +182,11 @@ type Model struct {
 	idleTimeout    time.Duration
 	lastActivity   time.Time
 	idlePaused     bool
-	latestVersion  string
-	downloadURL    string
-	checksumsURL   string
+	latestVersion       string
+	downloadURL         string
+	checksumsURL        string
+	noUpdateBuild       bool
+	updateCheckInterval time.Duration
 }
 
 // ShouldRestart returns true if the app quit due to a restart request.
@@ -200,6 +202,7 @@ type Options struct {
 	IdleTimeout     time.Duration
 	Version         string
 	CheckUpdate     bool
+	NoUpdateBuild   bool
 	Plain           bool
 	Config          *config.Config
 }
@@ -223,40 +226,44 @@ func New(opts Options) Model {
 			autoName = clouds[0]
 		}
 		return Model{
-			view:            viewCloudPicker,
-			cloudPicker:     cloudpicker.New(clouds, nil),
-			statusBar:       statusbar.New(opts.Version),
-			help:            help.New(),
-			quotaView:       quotaview.New(),
-			configView:      configview.New(opts.Config),
-			minWidth:        80,
-			minHeight:       20,
-			autoCloud:       autoName,
-			refreshInterval: refresh,
-			idleTimeout:     opts.IdleTimeout,
-			version:         opts.Version,
-			checkUpdate:     opts.CheckUpdate,
-			tabs:            tabs,
-			tabInited:       make([]bool, len(tabs)),
+			view:                viewCloudPicker,
+			cloudPicker:         cloudpicker.New(clouds, nil),
+			statusBar:           statusbar.New(opts.Version),
+			help:                help.New(),
+			quotaView:           quotaview.New(),
+			configView:          configview.New(opts.Config),
+			minWidth:            80,
+			minHeight:           20,
+			autoCloud:           autoName,
+			refreshInterval:     refresh,
+			idleTimeout:         opts.IdleTimeout,
+			version:             opts.Version,
+			checkUpdate:         opts.CheckUpdate,
+			noUpdateBuild:       opts.NoUpdateBuild,
+			updateCheckInterval: time.Duration(opts.Config.General.UpdateCheckInterval) * time.Hour,
+			tabs:                tabs,
+			tabInited:           make([]bool, len(tabs)),
 		}
 	}
 
 	cp := cloudpicker.New(clouds, err)
 	return Model{
-		view:            viewCloudPicker,
-		cloudPicker:     cp,
-		statusBar:       statusbar.New(opts.Version),
-		help:            help.New(),
-		quotaView:       quotaview.New(),
-		configView:      configview.New(opts.Config),
-		minWidth:        80,
-		minHeight:       20,
-		refreshInterval: refresh,
-		idleTimeout:     opts.IdleTimeout,
-		version:         opts.Version,
-		checkUpdate:     opts.CheckUpdate,
-		tabs:            tabs,
-		tabInited:       make([]bool, len(tabs)),
+		view:                viewCloudPicker,
+		cloudPicker:         cp,
+		statusBar:           statusbar.New(opts.Version),
+		help:                help.New(),
+		quotaView:           quotaview.New(),
+		configView:          configview.New(opts.Config),
+		minWidth:            80,
+		minHeight:           20,
+		refreshInterval:     refresh,
+		idleTimeout:         opts.IdleTimeout,
+		version:             opts.Version,
+		checkUpdate:         opts.CheckUpdate,
+		noUpdateBuild:       opts.NoUpdateBuild,
+		updateCheckInterval: time.Duration(opts.Config.General.UpdateCheckInterval) * time.Hour,
+		tabs:                tabs,
+		tabInited:           make([]bool, len(tabs)),
 	}
 }
 
@@ -271,8 +278,9 @@ func (m Model) Init() tea.Cmd {
 	}
 	if m.checkUpdate && m.version != "dev" {
 		ver := m.version
+		ttl := m.updateCheckInterval
 		cmds = append(cmds, func() tea.Msg {
-			latest, dlURL, csURL, err := selfupdate.CheckLatest(ver)
+			latest, dlURL, csURL, err := selfupdate.CheckLatestCached(ver, ttl)
 			if err != nil || latest == "" {
 				return nil
 			}
@@ -927,6 +935,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.latestVersion = msg.Latest
 		m.downloadURL = msg.DownloadURL
 		m.checksumsURL = msg.ChecksumsURL
+		if m.noUpdateBuild {
+			return m, nil
+		}
 		m.confirm = modal.ConfirmModel{
 			Action: "update",
 			Title:  "Update Available",
@@ -962,6 +973,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleDetailNavigation(msg)
 
 	case modal.ConfirmAction:
+		if msg.Action == "update" && m.noUpdateBuild {
+			m.activeModal = modalNone
+			return m, nil
+		}
 		if msg.Confirm && msg.Action == "update" {
 			m.updating = true
 			m.confirm.Title = "Updating"

--- a/src/internal/app/render.go
+++ b/src/internal/app/render.go
@@ -224,6 +224,23 @@ func (m Model) viewContent() string {
 			lines[1] = secondLine + strings.Repeat(" ", pad) + versionStr
 		}
 	}
+	if len(lines) > 2 && m.latestVersion != "" {
+		var indicator string
+		if shared.PlainMode {
+			indicator = lipgloss.NewStyle().Foreground(shared.ColorWarning).
+				Render("(update: " + m.latestVersion + ")")
+		} else {
+			indicator = lipgloss.NewStyle().Foreground(shared.ColorWarning).
+				Render("⚡ " + m.latestVersion + " available")
+		}
+		thirdLine := lines[2]
+		thirdW := lipgloss.Width(thirdLine)
+		indW := lipgloss.Width(indicator)
+		pad := m.width - thirdW - indW
+		if pad > 0 {
+			lines[2] = thirdLine + strings.Repeat(" ", pad) + indicator
+		}
+	}
 	content = strings.Join(lines, "\n")
 
 	contentHeight := m.height - 1

--- a/src/internal/app/update_test.go
+++ b/src/internal/app/update_test.go
@@ -4,14 +4,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/larkly/lazystack/internal/config"
 	"github.com/larkly/lazystack/internal/ui/modal"
 	"charm.land/bubbletea/v2"
 )
 
 func newTestModel(version string, checkUpdate bool) Model {
+	cfg := config.Defaults()
 	return New(Options{
 		Version:     version,
 		CheckUpdate: checkUpdate,
+		Config:      &cfg,
 	})
 }
 
@@ -170,6 +173,56 @@ func TestKeySwallowedWhileUpdating(t *testing.T) {
 	// Modal should still be active
 	if m.activeModal != modalConfirm {
 		t.Error("expected modal to remain active while updating")
+	}
+}
+
+func TestUpdateAvailableMsg_NoUpdateBuild_NoModal(t *testing.T) {
+	cfg := config.Defaults()
+	m := New(Options{
+		Version:       "v0.0.1",
+		CheckUpdate:   true,
+		NoUpdateBuild: true,
+		Config:        &cfg,
+	})
+	m.width = 100
+	m.height = 40
+
+	msg := UpdateAvailableMsg{
+		Latest:       "v0.1.1",
+		DownloadURL:  "https://example.com/bin",
+		ChecksumsURL: "https://example.com/SHA256SUMS",
+	}
+
+	result, _ := m.Update(msg)
+	m = result.(Model)
+
+	if m.activeModal != modalNone {
+		t.Error("expected no modal when noUpdateBuild is true")
+	}
+	if m.latestVersion != "v0.1.1" {
+		t.Errorf("latestVersion = %q, want %q", m.latestVersion, "v0.1.1")
+	}
+}
+
+func TestConfirmAction_Update_NoUpdateBuild_Blocked(t *testing.T) {
+	cfg := config.Defaults()
+	m := New(Options{
+		Version:       "v0.0.1",
+		NoUpdateBuild: true,
+		Config:        &cfg,
+	})
+	m.width = 100
+	m.height = 40
+	m.downloadURL = "https://example.com/bin"
+	m.latestVersion = "v0.1.1"
+	m.activeModal = modalConfirm
+
+	msg := modal.ConfirmAction{Action: "update", Confirm: true}
+	result, _ := m.Update(msg)
+	m = result.(Model)
+
+	if m.updating {
+		t.Error("expected updating to be false when noUpdateBuild is true")
 	}
 }
 

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -18,11 +18,12 @@ type Config struct {
 
 // GeneralConfig holds non-visual, non-keybinding settings.
 type GeneralConfig struct {
-	RefreshInterval int  `yaml:"refresh_interval"`
-	IdleTimeout     int  `yaml:"idle_timeout"`
-	PlainMode       bool `yaml:"plain_mode"`
-	CheckForUpdates bool `yaml:"check_for_updates"`
-	AlwaysPickCloud bool `yaml:"always_pick_cloud"`
+	RefreshInterval     int  `yaml:"refresh_interval"`
+	IdleTimeout         int  `yaml:"idle_timeout"`
+	PlainMode           bool `yaml:"plain_mode"`
+	CheckForUpdates     bool `yaml:"check_for_updates"`
+	AlwaysPickCloud     bool `yaml:"always_pick_cloud"`
+	UpdateCheckInterval int  `yaml:"update_check_interval"`
 }
 
 // ColorConfig holds hex color strings for the UI palette.
@@ -66,8 +67,9 @@ func Defaults() Config {
 			RefreshInterval: 5,
 			IdleTimeout:     0,
 			PlainMode:       false,
-			CheckForUpdates: true,
-			AlwaysPickCloud: false,
+			CheckForUpdates:     true,
+			AlwaysPickCloud:     false,
+			UpdateCheckInterval: 24,
 		},
 		Colors: ColorConfig{
 			Primary:   "#7D56F4",
@@ -151,11 +153,12 @@ func Load() (Config, error) {
 
 // rawGeneral mirrors GeneralConfig with pointer bools to detect presence in YAML.
 type rawGeneral struct {
-	RefreshInterval int   `yaml:"refresh_interval"`
-	IdleTimeout     int   `yaml:"idle_timeout"`
-	PlainMode       *bool `yaml:"plain_mode"`
-	CheckForUpdates *bool `yaml:"check_for_updates"`
-	AlwaysPickCloud *bool `yaml:"always_pick_cloud"`
+	RefreshInterval     int   `yaml:"refresh_interval"`
+	IdleTimeout         int   `yaml:"idle_timeout"`
+	PlainMode           *bool `yaml:"plain_mode"`
+	CheckForUpdates     *bool `yaml:"check_for_updates"`
+	AlwaysPickCloud     *bool `yaml:"always_pick_cloud"`
+	UpdateCheckInterval *int  `yaml:"update_check_interval"`
 }
 
 type rawConfig struct {
@@ -208,6 +211,11 @@ func LoadFrom(path string) (Config, error) {
 	} else {
 		file.General.AlwaysPickCloud = defaults.General.AlwaysPickCloud
 	}
+	if raw.General.UpdateCheckInterval != nil {
+		file.General.UpdateCheckInterval = *raw.General.UpdateCheckInterval
+	} else {
+		file.General.UpdateCheckInterval = defaults.General.UpdateCheckInterval
+	}
 
 	return mergeWithDefaults(file, defaults), nil
 }
@@ -217,6 +225,9 @@ func LoadFrom(path string) (Config, error) {
 func mergeWithDefaults(file, defaults Config) Config {
 	if file.General.RefreshInterval == 0 {
 		file.General.RefreshInterval = defaults.General.RefreshInterval
+	}
+	if file.General.UpdateCheckInterval == 0 {
+		file.General.UpdateCheckInterval = defaults.General.UpdateCheckInterval
 	}
 
 	if file.Colors.Primary == "" {

--- a/src/internal/selfupdate/cache.go
+++ b/src/internal/selfupdate/cache.go
@@ -1,0 +1,99 @@
+package selfupdate
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// CacheEntry holds the result of a previous update check.
+type CacheEntry struct {
+	CheckedAt      time.Time `json:"checked_at"`
+	LatestVersion  string    `json:"latest_version"`
+	DownloadURL    string    `json:"download_url"`
+	ChecksumsURL   string    `json:"checksums_url"`
+	CurrentVersion string    `json:"current_version"`
+}
+
+// CachePath returns the path to the update-check cache file.
+// It is a variable so tests can override it.
+var CachePath = func() string {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, "lazystack", "update-check.json")
+}
+
+// checkFn is the function used to query for the latest version.
+// It is a variable so tests can override it.
+var checkFn = CheckLatest
+
+// LoadCache reads the cached update-check result from disk.
+// Returns nil, nil if the file does not exist.
+func LoadCache() (*CacheEntry, error) {
+	path := CachePath()
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var entry CacheEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return nil, err
+	}
+	return &entry, nil
+}
+
+// SaveCache writes the update-check result to disk.
+func SaveCache(entry CacheEntry) error {
+	path := CachePath()
+	if path == "" {
+		return errors.New("cannot determine cache directory")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+// CheckLatestCached wraps CheckLatest with a disk cache to avoid
+// hitting the GitHub API on every launch. The API is only queried
+// if the cache is missing, expired (older than ttl), or was written
+// for a different binary version (i.e. the user upgraded via their
+// package manager).
+func CheckLatestCached(currentVersion string, ttl time.Duration) (latest, downloadURL, checksumsURL string, err error) {
+	cache, _ := LoadCache()
+	if cache != nil && cache.CurrentVersion == currentVersion && time.Since(cache.CheckedAt) < ttl {
+		if cache.LatestVersion == "" {
+			return "", "", "", nil
+		}
+		return cache.LatestVersion, cache.DownloadURL, cache.ChecksumsURL, nil
+	}
+
+	latest, downloadURL, checksumsURL, err = checkFn(currentVersion)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	_ = SaveCache(CacheEntry{
+		CheckedAt:      time.Now(),
+		LatestVersion:  latest,
+		DownloadURL:    downloadURL,
+		ChecksumsURL:   checksumsURL,
+		CurrentVersion: currentVersion,
+	})
+
+	return latest, downloadURL, checksumsURL, nil
+}

--- a/src/internal/selfupdate/cache_test.go
+++ b/src/internal/selfupdate/cache_test.go
@@ -1,0 +1,168 @@
+package selfupdate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSaveAndLoadCache(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "update-check.json")
+	origCachePath := CachePath
+	CachePath = func() string { return path }
+	defer func() { CachePath = origCachePath }()
+
+	entry := CacheEntry{
+		CheckedAt:      time.Now().Truncate(time.Second),
+		LatestVersion:  "v1.2.0",
+		DownloadURL:    "https://example.com/bin",
+		ChecksumsURL:   "https://example.com/SHA256SUMS",
+		CurrentVersion: "v1.1.0",
+	}
+
+	if err := SaveCache(entry); err != nil {
+		t.Fatalf("SaveCache: %v", err)
+	}
+
+	got, err := LoadCache()
+	if err != nil {
+		t.Fatalf("LoadCache: %v", err)
+	}
+	if got == nil {
+		t.Fatal("LoadCache returned nil")
+	}
+	if got.LatestVersion != entry.LatestVersion {
+		t.Errorf("LatestVersion = %q, want %q", got.LatestVersion, entry.LatestVersion)
+	}
+	if got.CurrentVersion != entry.CurrentVersion {
+		t.Errorf("CurrentVersion = %q, want %q", got.CurrentVersion, entry.CurrentVersion)
+	}
+	if got.DownloadURL != entry.DownloadURL {
+		t.Errorf("DownloadURL = %q, want %q", got.DownloadURL, entry.DownloadURL)
+	}
+}
+
+func TestLoadCache_NotExist(t *testing.T) {
+	origCachePath := CachePath
+	CachePath = func() string { return filepath.Join(t.TempDir(), "nonexistent.json") }
+	defer func() { CachePath = origCachePath }()
+
+	got, err := LoadCache()
+	if err != nil {
+		t.Fatalf("LoadCache: %v", err)
+	}
+	if got != nil {
+		t.Error("expected nil for nonexistent cache file")
+	}
+}
+
+func TestCheckLatestCached_UsesCacheWithinTTL(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "update-check.json")
+	origCachePath := CachePath
+	CachePath = func() string { return path }
+	defer func() { CachePath = origCachePath }()
+
+	// Pre-populate cache with a fresh entry
+	entry := CacheEntry{
+		CheckedAt:      time.Now(),
+		LatestVersion:  "v2.0.0",
+		DownloadURL:    "https://example.com/bin",
+		ChecksumsURL:   "https://example.com/SHA256SUMS",
+		CurrentVersion: "v1.0.0",
+	}
+	data, _ := json.Marshal(entry)
+	os.WriteFile(path, data, 0o600)
+
+	// Override checkFn to track if CheckLatest is called
+	called := false
+	origCheckFn := checkFn
+	checkFn = func(ver string) (string, string, string, error) {
+		called = true
+		return "", "", "", nil
+	}
+	defer func() { checkFn = origCheckFn }()
+
+	latest, _, _, err := CheckLatestCached("v1.0.0", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CheckLatestCached: %v", err)
+	}
+	if called {
+		t.Error("expected CheckLatest not to be called when cache is fresh")
+	}
+	if latest != "v2.0.0" {
+		t.Errorf("latest = %q, want %q", latest, "v2.0.0")
+	}
+}
+
+func TestCheckLatestCached_RefreshesExpiredCache(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "update-check.json")
+	origCachePath := CachePath
+	CachePath = func() string { return path }
+	defer func() { CachePath = origCachePath }()
+
+	// Pre-populate cache with an expired entry
+	entry := CacheEntry{
+		CheckedAt:      time.Now().Add(-48 * time.Hour),
+		LatestVersion:  "v1.5.0",
+		CurrentVersion: "v1.0.0",
+	}
+	data, _ := json.Marshal(entry)
+	os.WriteFile(path, data, 0o600)
+
+	called := false
+	origCheckFn := checkFn
+	checkFn = func(ver string) (string, string, string, error) {
+		called = true
+		return "v2.0.0", "https://example.com/bin2", "https://example.com/SHA256SUMS2", nil
+	}
+	defer func() { checkFn = origCheckFn }()
+
+	latest, _, _, err := CheckLatestCached("v1.0.0", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CheckLatestCached: %v", err)
+	}
+	if !called {
+		t.Error("expected CheckLatest to be called when cache is expired")
+	}
+	if latest != "v2.0.0" {
+		t.Errorf("latest = %q, want %q", latest, "v2.0.0")
+	}
+}
+
+func TestCheckLatestCached_InvalidatesOnVersionChange(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "update-check.json")
+	origCachePath := CachePath
+	CachePath = func() string { return path }
+	defer func() { CachePath = origCachePath }()
+
+	// Cache was written for v1.0.0 but we're now running v1.5.0
+	entry := CacheEntry{
+		CheckedAt:      time.Now(),
+		LatestVersion:  "v2.0.0",
+		CurrentVersion: "v1.0.0",
+	}
+	data, _ := json.Marshal(entry)
+	os.WriteFile(path, data, 0o600)
+
+	called := false
+	origCheckFn := checkFn
+	checkFn = func(ver string) (string, string, string, error) {
+		called = true
+		return "v2.0.0", "https://example.com/bin", "", nil
+	}
+	defer func() { checkFn = origCheckFn }()
+
+	_, _, _, err := CheckLatestCached("v1.5.0", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CheckLatestCached: %v", err)
+	}
+	if !called {
+		t.Error("expected CheckLatest to be called when current version differs from cached")
+	}
+}


### PR DESCRIPTION
## Summary
- Add a passive ⚡ update indicator (or `(update: vX.Y.Z)` in plain mode) below the version display when a newer release is available on GitHub
- Cache check results in `~/.cache/lazystack/update-check.json` with configurable TTL (`update_check_interval` in config, default 24h) to avoid repeated API calls
- Add `noUpdate` build flag (`-X main.noUpdate=true`) for package manager builds (RPM/DEB/AUR) that disables the update modal while preserving the passive indicator
- `--no-check-update` / `check_for_updates: false` still suppresses everything including the indicator

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass
- [x] Run TUI with a stale version — indicator appears on line 2 after async check
- [x] Run with `--no-check-update` — no indicator
- [x] Build with `-ldflags "-X main.noUpdate=true"` — no update modal, indicator still shows
- [x] Build with noUpdate + `--no-check-update` — no check at all
- [x] Run with `--plain` — shows `(update: vX.Y.Z)` text instead of ⚡