### PR TITLE
refactor: passive update notification, remove build flag

### DIFF
--- a/src/cmd/lazystack/main.go
+++ b/src/cmd/lazystack/main.go
@@ -17,7 +17,6 @@ import (
 )
 
 var version = "dev"
-var noUpdate = "false"
 
 func main() {
 	showVersion := flag.Bool("version", false, "print version and exit")
@@ -35,14 +34,7 @@ func main() {
 		return
 	}
 
-	noUpdateBuild := noUpdate == "true" || noUpdate == "1"
-
 	if *doUpdate {
-		if noUpdateBuild {
-			fmt.Fprintln(os.Stderr, "This build of lazystack is managed by your system package manager.")
-			fmt.Fprintln(os.Stderr, "Use your package manager to update (e.g., pacman -Syu, apt upgrade, dnf upgrade).")
-			os.Exit(1)
-		}
 		latest, downloadURL, checksumsURL, err := selfupdate.CheckLatest(version)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -109,7 +101,6 @@ func main() {
 		IdleTimeout:     time.Duration(cfg.General.IdleTimeout) * time.Minute,
 		Version:         version,
 		CheckUpdate:     cfg.General.CheckForUpdates,
-		NoUpdateBuild:   noUpdateBuild,
 		Plain:           cfg.General.PlainMode,
 		Config:          &cfg,
 	})

--- a/src/internal/app/app.go
+++ b/src/internal/app/app.go
@@ -93,11 +93,6 @@ type UpdateAvailableMsg struct {
 	ChecksumsURL string
 }
 
-// UpdateResultMsg is sent after selfupdate.Apply completes.
-type UpdateResultMsg struct {
-	Err error
-}
-
 type delayedDetailRefreshMsg struct {
 	id string
 }
@@ -178,14 +173,12 @@ type Model struct {
 	restart        bool
 	version        string
 	checkUpdate    bool
-	updating       bool
 	idleTimeout    time.Duration
 	lastActivity   time.Time
 	idlePaused     bool
 	latestVersion       string
 	downloadURL         string
 	checksumsURL        string
-	noUpdateBuild       bool
 	updateCheckInterval time.Duration
 }
 
@@ -201,10 +194,9 @@ type Options struct {
 	RefreshInterval time.Duration
 	IdleTimeout     time.Duration
 	Version         string
-	CheckUpdate     bool
-	NoUpdateBuild   bool
-	Plain           bool
-	Config          *config.Config
+	CheckUpdate bool
+	Plain       bool
+	Config      *config.Config
 }
 
 // New creates the root model.
@@ -239,7 +231,6 @@ func New(opts Options) Model {
 			idleTimeout:         opts.IdleTimeout,
 			version:             opts.Version,
 			checkUpdate:         opts.CheckUpdate,
-			noUpdateBuild:       opts.NoUpdateBuild,
 			updateCheckInterval: time.Duration(opts.Config.General.UpdateCheckInterval) * time.Hour,
 			tabs:                tabs,
 			tabInited:           make([]bool, len(tabs)),
@@ -260,7 +251,6 @@ func New(opts Options) Model {
 		idleTimeout:         opts.IdleTimeout,
 		version:             opts.Version,
 		checkUpdate:         opts.CheckUpdate,
-		noUpdateBuild:       opts.NoUpdateBuild,
 		updateCheckInterval: time.Duration(opts.Config.General.UpdateCheckInterval) * time.Hour,
 		tabs:                tabs,
 		tabInited:           make([]bool, len(tabs)),
@@ -359,9 +349,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		if m.activeModal != modalNone {
-			if m.updating {
-				return m, nil // swallow keys while update is downloading
-			}
 			return m.updateModal(msg)
 		}
 
@@ -935,28 +922,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.latestVersion = msg.Latest
 		m.downloadURL = msg.DownloadURL
 		m.checksumsURL = msg.ChecksumsURL
-		if m.noUpdateBuild {
-			return m, nil
-		}
-		m.confirm = modal.ConfirmModel{
-			Action: "update",
-			Title:  "Update Available",
-			Body:   fmt.Sprintf("New version available: %s (current: %s). Upgrade now?", msg.Latest, m.version),
-		}
-		m.confirm.SetSize(m.width, m.height)
-		m.activeModal = modalConfirm
+		m.statusBar.Hint = fmt.Sprintf("Upgrade available: %s", msg.Latest)
 		return m, nil
-
-	case UpdateResultMsg:
-		m.updating = false
-		if msg.Err != nil {
-			m.errModal = modal.NewError("Update failed", msg.Err)
-			m.errModal.SetSize(m.width, m.height)
-			m.activeModal = modalError
-			return m, nil
-		}
-		m.restart = true
-		return m, tea.Quit
 
 	case shared.ConfigChangedMsg:
 		m.refreshInterval = time.Duration(m.configView.Cfg().General.RefreshInterval) * time.Second
@@ -973,26 +940,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleDetailNavigation(msg)
 
 	case modal.ConfirmAction:
-		if msg.Action == "update" && m.noUpdateBuild {
-			m.activeModal = modalNone
-			return m, nil
-		}
-		if msg.Confirm && msg.Action == "update" {
-			m.updating = true
-			m.confirm.Title = "Updating"
-			m.confirm.Body = fmt.Sprintf("Downloading %s, please wait...", m.latestVersion)
-			dlURL := m.downloadURL
-			csURL := m.checksumsURL
-			return m, func() tea.Msg {
-				return UpdateResultMsg{Err: selfupdate.Apply(dlURL, csURL)}
-			}
-		}
 		m.activeModal = modalNone
 		if msg.Confirm {
 			return m.executeAction(msg)
-		}
-		if msg.Action == "update" {
-			m.statusBar.Hint = fmt.Sprintf("Upgrade available: %s — use --update", m.latestVersion)
 		}
 		return m, nil
 

--- a/src/internal/app/update_test.go
+++ b/src/internal/app/update_test.go
@@ -2,11 +2,8 @@ package app
 
 import (
 	"testing"
-	"time"
 
 	"github.com/larkly/lazystack/internal/config"
-	"github.com/larkly/lazystack/internal/ui/modal"
-	"charm.land/bubbletea/v2"
 )
 
 func newTestModel(version string, checkUpdate bool) Model {
@@ -43,8 +40,8 @@ func TestInit_CheckUpdateDisabled(t *testing.T) {
 	}
 }
 
-func TestUpdateAvailableMsg_ShowsModal(t *testing.T) {
-	m := newTestModel("v0.0.1", false)
+func TestUpdateAvailableMsg_SetsHint(t *testing.T) {
+	m := newTestModel("v0.0.1", true)
 	m.width = 100
 	m.height = 40
 
@@ -57,8 +54,8 @@ func TestUpdateAvailableMsg_ShowsModal(t *testing.T) {
 	result, _ := m.Update(msg)
 	m = result.(Model)
 
-	if m.activeModal != modalConfirm {
-		t.Error("expected confirm modal to be active")
+	if m.activeModal != modalNone {
+		t.Error("expected no modal for update available")
 	}
 	if m.latestVersion != "v0.1.1" {
 		t.Errorf("latestVersion = %q, want %q", m.latestVersion, "v0.1.1")
@@ -66,163 +63,8 @@ func TestUpdateAvailableMsg_ShowsModal(t *testing.T) {
 	if m.downloadURL != "https://example.com/bin" {
 		t.Errorf("downloadURL = %q, want %q", m.downloadURL, "https://example.com/bin")
 	}
-	if m.confirm.Action != "update" {
-		t.Errorf("confirm.Action = %q, want %q", m.confirm.Action, "update")
-	}
-}
-
-func TestConfirmAction_Update_SetsUpdating(t *testing.T) {
-	m := newTestModel("v0.0.1", false)
-	m.width = 100
-	m.height = 40
-	m.downloadURL = "https://example.com/bin"
-	m.checksumsURL = "https://example.com/SHA256SUMS"
-	m.latestVersion = "v0.1.1"
-	m.activeModal = modalConfirm
-
-	msg := modal.ConfirmAction{Action: "update", Confirm: true}
-	result, cmd := m.Update(msg)
-	m = result.(Model)
-
-	if !m.updating {
-		t.Error("expected updating to be true")
-	}
-	if cmd == nil {
-		t.Error("expected a cmd to be returned for selfupdate.Apply")
-	}
-	if m.confirm.Title != "Updating" {
-		t.Errorf("confirm.Title = %q, want %q", m.confirm.Title, "Updating")
-	}
-}
-
-func TestConfirmAction_Update_Declined(t *testing.T) {
-	m := newTestModel("v0.0.1", false)
-	m.width = 100
-	m.height = 40
-	m.latestVersion = "v0.1.1"
-	m.activeModal = modalConfirm
-
-	msg := modal.ConfirmAction{Action: "update", Confirm: false}
-	result, _ := m.Update(msg)
-	m = result.(Model)
-
-	if m.activeModal != modalNone {
-		t.Error("expected modal to be dismissed")
-	}
 	if m.statusBar.Hint == "" {
 		t.Error("expected status bar hint about available upgrade")
-	}
-}
-
-func TestUpdateResultMsg_Success(t *testing.T) {
-	m := newTestModel("v0.0.1", false)
-	m.updating = true
-	m.latestVersion = "v0.1.1"
-
-	result, cmd := m.Update(UpdateResultMsg{Err: nil})
-	m = result.(Model)
-
-	if m.updating {
-		t.Error("expected updating to be false")
-	}
-	if !m.restart {
-		t.Error("expected restart to be true")
-	}
-	// cmd should be tea.Quit
-	if cmd == nil {
-		t.Error("expected quit cmd")
-	}
-}
-
-func TestUpdateResultMsg_Failure(t *testing.T) {
-	m := newTestModel("v0.0.1", false)
-	m.width = 100
-	m.height = 40
-	m.updating = true
-
-	result, _ := m.Update(UpdateResultMsg{Err: errTest})
-	m = result.(Model)
-
-	if m.updating {
-		t.Error("expected updating to be false")
-	}
-	if m.activeModal != modalError {
-		t.Error("expected error modal to be active")
-	}
-	if m.restart {
-		t.Error("expected restart to be false on failure")
-	}
-}
-
-func TestKeySwallowedWhileUpdating(t *testing.T) {
-	m := newTestModel("v0.0.1", false)
-	m.width = 100
-	m.height = 40
-	m.activeModal = modalConfirm
-	m.updating = true
-	m.refreshInterval = 5 * time.Second
-
-	// Pressing 'y' should be swallowed
-	keyMsg := tea.KeyPressMsg(tea.Key{Code: 'y', Text: "y"})
-	result, cmd := m.Update(keyMsg)
-	m = result.(Model)
-
-	if cmd != nil {
-		t.Error("expected nil cmd when keys are swallowed during update")
-	}
-	// Modal should still be active
-	if m.activeModal != modalConfirm {
-		t.Error("expected modal to remain active while updating")
-	}
-}
-
-func TestUpdateAvailableMsg_NoUpdateBuild_NoModal(t *testing.T) {
-	cfg := config.Defaults()
-	m := New(Options{
-		Version:       "v0.0.1",
-		CheckUpdate:   true,
-		NoUpdateBuild: true,
-		Config:        &cfg,
-	})
-	m.width = 100
-	m.height = 40
-
-	msg := UpdateAvailableMsg{
-		Latest:       "v0.1.1",
-		DownloadURL:  "https://example.com/bin",
-		ChecksumsURL: "https://example.com/SHA256SUMS",
-	}
-
-	result, _ := m.Update(msg)
-	m = result.(Model)
-
-	if m.activeModal != modalNone {
-		t.Error("expected no modal when noUpdateBuild is true")
-	}
-	if m.latestVersion != "v0.1.1" {
-		t.Errorf("latestVersion = %q, want %q", m.latestVersion, "v0.1.1")
-	}
-}
-
-func TestConfirmAction_Update_NoUpdateBuild_Blocked(t *testing.T) {
-	cfg := config.Defaults()
-	m := New(Options{
-		Version:       "v0.0.1",
-		NoUpdateBuild: true,
-		Config:        &cfg,
-	})
-	m.width = 100
-	m.height = 40
-	m.downloadURL = "https://example.com/bin"
-	m.latestVersion = "v0.1.1"
-	m.activeModal = modalConfirm
-
-	msg := modal.ConfirmAction{Action: "update", Confirm: true}
-	result, _ := m.Update(msg)
-	m = result.(Model)
-
-	if m.updating {
-		t.Error("expected updating to be false when noUpdateBuild is true")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Remove the automatic upgrade modal that interrupted users on update detection
- Show update availability passively via the status bar indicator only
- Remove the `noUpdate` build flag and `NoUpdateBuild` option — a single binary now works for all distribution channels (AUR, DEB, RPM, Homebrew, standalone)
- Manual upgrade via `--update` CLI flag remains available
- Update check opt-out via `--no-check-update` / `check_for_updates: false` unchanged

## Test plan
- [x] `go build ./...` compiles
- [x] `go test ./...` all pass
- [ ] Run app with outdated version — verify status bar shows upgrade indicator, no modal
- [ ] Run `--update` — verify manual upgrade still works
- [ ] Run `--no-check-update` — verify no update check or indicator