### PR TITLE
feat: multi-pane load balancer detail view with health monitors

### DIFF
--- a/src/internal/loadbalancer/lb.go
+++ b/src/internal/loadbalancer/lb.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/listeners"
 	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/loadbalancers"
+	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/monitors"
 	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/pools"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
@@ -34,10 +35,11 @@ type Listener struct {
 
 // Pool is a simplified pool.
 type Pool struct {
-	ID       string
-	Name     string
-	Protocol string
-	LBMethod string
+	ID        string
+	Name      string
+	Protocol  string
+	LBMethod  string
+	MonitorID string
 }
 
 // Member is a simplified pool member.
@@ -48,6 +50,23 @@ type Member struct {
 	ProtocolPort    int
 	Weight          int
 	OperatingStatus string
+}
+
+// HealthMonitor is a simplified health monitor.
+type HealthMonitor struct {
+	ID                 string
+	Name               string
+	Type               string
+	Delay              int
+	Timeout            int
+	MaxRetries         int
+	MaxRetriesDown     int
+	HTTPMethod         string
+	URLPath            string
+	ExpectedCodes      string
+	AdminStateUp       bool
+	OperatingStatus    string
+	ProvisioningStatus string
 }
 
 // ListLoadBalancers fetches all load balancers.
@@ -140,10 +159,11 @@ func ListPools(ctx context.Context, client *gophercloud.ServiceClient, lbID stri
 		}
 		for _, p := range extracted {
 			result = append(result, Pool{
-				ID:       p.ID,
-				Name:     p.Name,
-				Protocol: p.Protocol,
-				LBMethod: p.LBMethod,
+				ID:        p.ID,
+				Name:      p.Name,
+				Protocol:  p.Protocol,
+				LBMethod:  p.LBMethod,
+				MonitorID: p.MonitorID,
 			})
 		}
 		return true, nil
@@ -152,6 +172,29 @@ func ListPools(ctx context.Context, client *gophercloud.ServiceClient, lbID stri
 		return nil, fmt.Errorf("listing pools for LB %s: %w", lbID, err)
 	}
 	return result, nil
+}
+
+// GetHealthMonitor fetches a single health monitor by ID.
+func GetHealthMonitor(ctx context.Context, client *gophercloud.ServiceClient, id string) (*HealthMonitor, error) {
+	mon, err := monitors.Get(ctx, client, id).Extract()
+	if err != nil {
+		return nil, fmt.Errorf("getting health monitor %s: %w", id, err)
+	}
+	return &HealthMonitor{
+		ID:                 mon.ID,
+		Name:               mon.Name,
+		Type:               mon.Type,
+		Delay:              mon.Delay,
+		Timeout:            mon.Timeout,
+		MaxRetries:         mon.MaxRetries,
+		MaxRetriesDown:     mon.MaxRetriesDown,
+		HTTPMethod:         mon.HTTPMethod,
+		URLPath:            mon.URLPath,
+		ExpectedCodes:      mon.ExpectedCodes,
+		AdminStateUp:       mon.AdminStateUp,
+		OperatingStatus:    mon.OperatingStatus,
+		ProvisioningStatus: mon.ProvisioningStatus,
+	}, nil
 }
 
 // ListMembers fetches members for a pool.

--- a/src/internal/ui/help/help.go
+++ b/src/internal/ui/help/help.go
@@ -214,7 +214,9 @@ var allSections = []section{
 	{
 		name: "LB Detail",
 		binds: []string{
-			"↑/k ↓/j      scroll",
+			"↑/k ↓/j      navigate in pane",
+			"tab/shift+tab cycle panes",
+			"ctrl+d        delete load balancer",
 			"esc           back to list",
 		},
 	},

--- a/src/internal/ui/lbdetail/lbdetail.go
+++ b/src/internal/ui/lbdetail/lbdetail.go
@@ -16,11 +16,26 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 )
 
+type focusPane int
+
+const (
+	focusInfo focusPane = iota
+	focusListeners
+	focusPools
+	focusMembers
+)
+
+const focusPaneCount = 4
+const narrowThreshold = 80
+
+var selectedRowStyle = lipgloss.NewStyle().Background(lipgloss.Color("#073642")).Bold(true)
+
 type lbDetailLoadedMsg struct {
 	lb        *loadbalancer.LoadBalancer
 	listeners []loadbalancer.Listener
 	pools     []loadbalancer.Pool
 	members   map[string][]loadbalancer.Member
+	monitors  map[string]*loadbalancer.HealthMonitor
 }
 
 type lbDetailErrMsg struct {
@@ -37,13 +52,22 @@ type Model struct {
 	listeners       []loadbalancer.Listener
 	pools           []loadbalancer.Pool
 	members         map[string][]loadbalancer.Member
+	monitors        map[string]*loadbalancer.HealthMonitor
 	loading         bool
 	spinner         spinner.Model
 	width           int
 	height          int
-	scroll          int
 	err             string
 	refreshInterval time.Duration
+
+	// Pane focus and cursors
+	focus          focusPane
+	listenerCursor int
+	listenerScroll int
+	poolCursor     int
+	poolScroll     int
+	memberCursor   int
+	memberScroll   int
 }
 
 // New creates a load balancer detail model.
@@ -56,6 +80,7 @@ func New(client *gophercloud.ServiceClient, lbID string, refreshInterval time.Du
 		loading:         true,
 		spinner:         s,
 		members:         make(map[string][]loadbalancer.Member),
+		monitors:        make(map[string]*loadbalancer.HealthMonitor),
 		refreshInterval: refreshInterval,
 	}
 }
@@ -90,7 +115,9 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		m.listeners = msg.listeners
 		m.pools = msg.pools
 		m.members = msg.members
+		m.monitors = msg.monitors
 		m.err = ""
+		m.clampCursors()
 		return m, nil
 
 	case lbDetailErrMsg:
@@ -115,30 +142,230 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
-		switch {
-		case key.Matches(msg, shared.Keys.Back):
-			return m, func() tea.Msg {
-				return shared.ViewChangeMsg{View: "lblist"}
-			}
-		case key.Matches(msg, shared.Keys.Up):
-			if m.scroll > 0 {
-				m.scroll--
-			}
-		case key.Matches(msg, shared.Keys.Down):
-			m.scroll++
-		case key.Matches(msg, shared.Keys.PageDown):
-			m.scroll += m.height - 5
-		case key.Matches(msg, shared.Keys.PageUp):
-			m.scroll -= m.height - 5
-			if m.scroll < 0 {
-				m.scroll = 0
-			}
-		}
+		return m.handleKey(msg)
 	}
 	return m, nil
 }
 
-// View renders the load balancer detail.
+func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
+	switch {
+	case key.Matches(msg, shared.Keys.Back):
+		return m, func() tea.Msg {
+			return shared.ViewChangeMsg{View: "lblist"}
+		}
+
+	case key.Matches(msg, shared.Keys.Tab):
+		m.focus = (m.focus + 1) % focusPaneCount
+		return m, nil
+
+	case key.Matches(msg, shared.Keys.ShiftTab):
+		m.focus = (m.focus + focusPaneCount - 1) % focusPaneCount
+		return m, nil
+
+	case key.Matches(msg, shared.Keys.Up):
+		return m.scrollUp(1), nil
+
+	case key.Matches(msg, shared.Keys.Down):
+		return m.scrollDown(1), nil
+
+	case key.Matches(msg, shared.Keys.PageUp):
+		return m.scrollUp(10), nil
+
+	case key.Matches(msg, shared.Keys.PageDown):
+		return m.scrollDown(10), nil
+	}
+	return m, nil
+}
+
+func (m Model) scrollUp(n int) Model {
+	switch m.focus {
+	case focusListeners:
+		m.listenerCursor -= n
+		if m.listenerCursor < 0 {
+			m.listenerCursor = 0
+		}
+		m.ensureListenerCursorVisible()
+	case focusPools:
+		prev := m.poolCursor
+		m.poolCursor -= n
+		if m.poolCursor < 0 {
+			m.poolCursor = 0
+		}
+		m.ensurePoolCursorVisible()
+		if m.poolCursor != prev {
+			m.memberCursor = 0
+			m.memberScroll = 0
+		}
+	case focusMembers:
+		m.memberCursor -= n
+		if m.memberCursor < 0 {
+			m.memberCursor = 0
+		}
+		m.ensureMemberCursorVisible()
+	}
+	return m
+}
+
+func (m Model) scrollDown(n int) Model {
+	switch m.focus {
+	case focusListeners:
+		m.listenerCursor += n
+		maxIdx := len(m.listeners) - 1
+		if maxIdx < 0 {
+			maxIdx = 0
+		}
+		if m.listenerCursor > maxIdx {
+			m.listenerCursor = maxIdx
+		}
+		m.ensureListenerCursorVisible()
+	case focusPools:
+		prev := m.poolCursor
+		m.poolCursor += n
+		maxIdx := len(m.pools) - 1
+		if maxIdx < 0 {
+			maxIdx = 0
+		}
+		if m.poolCursor > maxIdx {
+			m.poolCursor = maxIdx
+		}
+		m.ensurePoolCursorVisible()
+		if m.poolCursor != prev {
+			m.memberCursor = 0
+			m.memberScroll = 0
+		}
+	case focusMembers:
+		m.memberCursor += n
+		members := m.selectedPoolMembers()
+		maxIdx := len(members) - 1
+		if maxIdx < 0 {
+			maxIdx = 0
+		}
+		if m.memberCursor > maxIdx {
+			m.memberCursor = maxIdx
+		}
+		m.ensureMemberCursorVisible()
+	}
+	return m
+}
+
+func (m *Model) clampCursors() {
+	if m.listenerCursor >= len(m.listeners) {
+		m.listenerCursor = max(0, len(m.listeners)-1)
+	}
+	if m.poolCursor >= len(m.pools) {
+		m.poolCursor = max(0, len(m.pools)-1)
+	}
+	members := m.selectedPoolMembers()
+	if m.memberCursor >= len(members) {
+		m.memberCursor = max(0, len(members)-1)
+	}
+}
+
+func (m Model) selectedPoolID() string {
+	if m.poolCursor >= 0 && m.poolCursor < len(m.pools) {
+		return m.pools[m.poolCursor].ID
+	}
+	return ""
+}
+
+func (m Model) selectedPoolMembers() []loadbalancer.Member {
+	id := m.selectedPoolID()
+	if id == "" {
+		return nil
+	}
+	return m.members[id]
+}
+
+func (m Model) selectedPoolMonitor() *loadbalancer.HealthMonitor {
+	if m.poolCursor >= 0 && m.poolCursor < len(m.pools) {
+		return m.monitors[m.pools[m.poolCursor].MonitorID]
+	}
+	return nil
+}
+
+// --- Cursor visibility ---
+
+func (m *Model) ensureListenerCursorVisible() {
+	visH := m.topVisibleLines()
+	if m.listenerCursor < m.listenerScroll {
+		m.listenerScroll = m.listenerCursor
+	}
+	if m.listenerCursor >= m.listenerScroll+visH {
+		m.listenerScroll = m.listenerCursor - visH + 1
+	}
+}
+
+func (m *Model) ensurePoolCursorVisible() {
+	visH := m.bottomVisibleLines()
+	// Account for health monitor reserved space
+	if m.selectedPoolMonitor() != nil {
+		visH -= 8
+		if visH < 1 {
+			visH = 1
+		}
+	}
+	if m.poolCursor < m.poolScroll {
+		m.poolScroll = m.poolCursor
+	}
+	if m.poolCursor >= m.poolScroll+visH {
+		m.poolScroll = m.poolCursor - visH + 1
+	}
+}
+
+func (m *Model) ensureMemberCursorVisible() {
+	visH := m.bottomVisibleLines()
+	if m.memberCursor < m.memberScroll {
+		m.memberScroll = m.memberCursor
+	}
+	if m.memberCursor >= m.memberScroll+visH {
+		m.memberScroll = m.memberCursor - visH + 1
+	}
+}
+
+// --- Height calculations ---
+
+func (m Model) totalPanelHeight() int {
+	h := m.height - 6 // title + blank + action bar + spacer + status bar + newline
+	if h < 10 {
+		h = 10
+	}
+	return h
+}
+
+func (m Model) topHeight() int {
+	h := m.totalPanelHeight() * 45 / 100
+	if h < 6 {
+		h = 6
+	}
+	return h
+}
+
+func (m Model) bottomHeight() int {
+	h := m.totalPanelHeight() - m.topHeight()
+	if h < 6 {
+		h = 6
+	}
+	return h
+}
+
+func (m Model) topVisibleLines() int {
+	lines := m.topHeight() - 5 // border(4) + header(1)
+	if lines < 1 {
+		lines = 1
+	}
+	return lines
+}
+
+func (m Model) bottomVisibleLines() int {
+	lines := m.bottomHeight() - 5 // border(4) + header(1)
+	if lines < 1 {
+		lines = 1
+	}
+	return lines
+}
+
+// --- View ---
+
 func (m Model) View() string {
 	var b strings.Builder
 
@@ -157,22 +384,149 @@ func (m Model) View() string {
 		return b.String()
 	}
 
+	if m.width < narrowThreshold {
+		b.WriteString(m.renderNarrow())
+	} else {
+		b.WriteString(m.renderWide())
+	}
+
+	b.WriteString("\n" + m.renderActionBar() + "\n")
+
+	return b.String()
+}
+
+func (m Model) renderWide() string {
+	topH := m.topHeight()
+	bottomH := m.bottomHeight()
+
+	leftW := m.width * 35 / 100
+	rightW := m.width - leftW - 1
+
+	infoContent := padContent(m.panelTitle(focusInfo), m.renderInfoContent(leftW-4))
+	infoPanel := m.panelBorder(focusInfo).Width(leftW).Height(topH).Render(infoContent)
+
+	listenersContent := padContent(m.panelTitle(focusListeners), m.renderListenersContent(rightW-4, topH-4))
+	listenersPanel := m.panelBorder(focusListeners).Width(rightW).Height(topH).Render(listenersContent)
+
+	poolsContent := padContent(m.panelTitle(focusPools), m.renderPoolsContent(leftW-4, bottomH-4))
+	poolsPanel := m.panelBorder(focusPools).Width(leftW).Height(bottomH).Render(poolsContent)
+
+	membersContent := padContent(m.panelTitle(focusMembers), m.renderMembersContent(rightW-4, bottomH-4))
+	membersPanel := m.panelBorder(focusMembers).Width(rightW).Height(bottomH).Render(membersContent)
+
+	topRow := lipgloss.JoinHorizontal(lipgloss.Top, infoPanel, " ", listenersPanel)
+	bottomRow := lipgloss.JoinHorizontal(lipgloss.Top, poolsPanel, " ", membersPanel)
+
+	return topRow + "\n" + bottomRow
+}
+
+func (m Model) renderNarrow() string {
+	w := m.width - 2
+	totalH := m.totalPanelHeight()
+
+	infoH := totalH * 25 / 100
+	listenersH := totalH * 25 / 100
+	poolsH := totalH * 25 / 100
+	membersH := totalH - infoH - listenersH - poolsH
+
+	for _, h := range []*int{&infoH, &listenersH, &poolsH, &membersH} {
+		if *h < 4 {
+			*h = 4
+		}
+	}
+
+	infoPanel := m.panelBorder(focusInfo).Width(w).Height(infoH).Render(padContent(m.panelTitle(focusInfo), m.renderInfoContent(w-4)))
+	listenersPanel := m.panelBorder(focusListeners).Width(w).Height(listenersH).Render(padContent(m.panelTitle(focusListeners), m.renderListenersContent(w-4, listenersH-4)))
+	poolsPanel := m.panelBorder(focusPools).Width(w).Height(poolsH).Render(padContent(m.panelTitle(focusPools), m.renderPoolsContent(w-4, poolsH-4)))
+	membersPanel := m.panelBorder(focusMembers).Width(w).Height(membersH).Render(padContent(m.panelTitle(focusMembers), m.renderMembersContent(w-4, membersH-4)))
+
+	return lipgloss.JoinVertical(lipgloss.Left, infoPanel, listenersPanel, poolsPanel, membersPanel)
+}
+
+// --- Panel helpers ---
+
+func padContent(title, content string) string {
+	var out []string
+	out = append(out, " "+title)
+	out = append(out, "")
+	if content != "" {
+		for _, l := range strings.Split(content, "\n") {
+			out = append(out, " "+l)
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+func (m Model) panelTitle(pane focusPane) string {
+	borderColor := shared.ColorMuted
+	if m.focus == pane {
+		borderColor = shared.ColorPrimary
+	}
+	titleStyle := lipgloss.NewStyle().Foreground(borderColor).Bold(true)
+
+	switch pane {
+	case focusInfo:
+		return titleStyle.Render("Info")
+	case focusListeners:
+		t := titleStyle.Render("Listeners")
+		if m.loading {
+			t += " " + m.spinner.View()
+		}
+		return t
+	case focusPools:
+		t := titleStyle.Render("Pools")
+		if m.loading {
+			t += " " + m.spinner.View()
+		}
+		return t
+	case focusMembers:
+		t := titleStyle.Render("Members")
+		poolName := ""
+		if m.poolCursor >= 0 && m.poolCursor < len(m.pools) {
+			poolName = m.pools[m.poolCursor].Name
+		}
+		if poolName != "" {
+			t += " " + lipgloss.NewStyle().Foreground(shared.ColorMuted).Render("("+poolName+")")
+		}
+		if m.loading {
+			t += " " + m.spinner.View()
+		}
+		return t
+	}
+	return ""
+}
+
+func (m Model) panelBorder(pane focusPane) lipgloss.Style {
+	borderColor := shared.ColorMuted
+	if m.focus == pane {
+		borderColor = shared.ColorPrimary
+	}
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(borderColor).
+		BorderTop(true).BorderBottom(true).BorderLeft(true).BorderRight(true)
+}
+
+// --- Info rendering ---
+
+func (m Model) renderInfoContent(maxWidth int) string {
+	if m.lb == nil {
+		return ""
+	}
+
 	lb := m.lb
+	labelW := 12
+	labelStyle := lipgloss.NewStyle().Foreground(shared.ColorSecondary).Bold(true).Width(labelW)
+	valueStyle := lipgloss.NewStyle().Foreground(shared.ColorFg)
 
-	lines := make([]string, 0, 32)
-
-	// Header
-	headerLine := fmt.Sprintf("  %s",
-		lipgloss.NewStyle().Bold(true).Foreground(shared.ColorPrimary).
-			Render(fmt.Sprintf("=== Load Balancer: %s ===", displayName(lb.Name, lb.ID))))
-	lines = append(lines, headerLine, "")
-
-	// Properties
-	props := []struct {
+	type prop struct {
 		label string
 		value string
 		style func(string) lipgloss.Style
-	}{
+	}
+
+	allProps := []prop{
+		{"Name", lb.Name, nil},
 		{"ID", lb.ID, nil},
 		{"VIP Address", lb.VipAddress, nil},
 		{"Prov Status", lb.ProvisioningStatus, provStatusStyleFn},
@@ -181,104 +535,419 @@ func (m Model) View() string {
 		{"Description", lb.Description, nil},
 	}
 
-	for _, p := range props {
+	valW := maxWidth - labelW
+	if valW < 4 {
+		valW = 4
+	}
+
+	var rows []string
+	for _, p := range allProps {
 		if p.value == "" {
 			continue
 		}
-		label := shared.StyleLabel.Render(p.label)
+		label := labelStyle.Render(p.label)
+		val := p.value
+		if lipgloss.Width(val) > valW {
+			val = val[:valW-1] + "\u2026"
+		}
 		var value string
 		if p.style != nil {
-			value = p.style(p.value).Render(shared.StatusIcon(p.value) + p.value)
+			value = p.style(p.value).Render(shared.StatusIcon(p.value) + val)
 		} else {
-			value = shared.StyleValue.Render(p.value)
+			value = valueStyle.Render(val)
 		}
-		lines = append(lines, fmt.Sprintf("  %s %s", label, value))
+		rows = append(rows, label+value)
 	}
 
-	// Listeners section
-	if len(m.listeners) > 0 {
-		lines = append(lines, "")
-		lines = append(lines, fmt.Sprintf("  %s",
-			lipgloss.NewStyle().Bold(true).Foreground(shared.ColorSecondary).Render("--- Listeners ---")))
-		lines = append(lines, "")
+	// Summary line
+	rows = append(rows, "")
+	summaryStyle := lipgloss.NewStyle().Foreground(shared.ColorMuted)
+	rows = append(rows, summaryStyle.Render(fmt.Sprintf("%d listeners, %d pools", len(m.listeners), len(m.pools))))
 
-		// Build a pool name lookup
-		poolNames := make(map[string]string)
-		for _, p := range m.pools {
-			poolNames[p.ID] = p.Name
-		}
-
-		for _, l := range m.listeners {
-			poolName := poolNames[l.DefaultPoolID]
-			if poolName == "" && l.DefaultPoolID != "" {
-				poolName = l.DefaultPoolID[:min(8, len(l.DefaultPoolID))] + "..."
-			}
-			arrow := ""
-			if poolName != "" {
-				arrow = fmt.Sprintf(" -> %s", poolName)
-			}
-			lines = append(lines, fmt.Sprintf("    %s %s :%d%s",
-				lipgloss.NewStyle().Foreground(shared.ColorHighlight).Render("->"),
-				l.Protocol, l.ProtocolPort, arrow))
-		}
-	}
-
-	// Pools section
-	if len(m.pools) > 0 {
-		lines = append(lines, "")
-		lines = append(lines, fmt.Sprintf("  %s",
-			lipgloss.NewStyle().Bold(true).Foreground(shared.ColorSecondary).Render("--- Pools ---")))
-		lines = append(lines, "")
-
-		for _, p := range m.pools {
-			lines = append(lines, fmt.Sprintf("    %s %s (%s, %s)",
-				lipgloss.NewStyle().Foreground(shared.ColorHighlight).Render("->"),
-				p.Name, p.LBMethod, p.Protocol))
-
-			members := m.members[p.ID]
-			if len(members) > 0 {
-				lines = append(lines, fmt.Sprintf("      %s",
-					shared.StyleLabel.Render("Members:")))
-				for _, mem := range members {
-					statusStyle := memberStatusStyle(mem.OperatingStatus)
-					lines = append(lines, fmt.Sprintf("        %s:%d  w:%d  %s",
-						mem.Address, mem.ProtocolPort, mem.Weight,
-						statusStyle.Render(mem.OperatingStatus)))
-				}
-			}
-		}
-	}
-
-	// Scroll
-	viewHeight := m.height - 5
-	if viewHeight < 1 {
-		viewHeight = 1
-	}
-	if m.scroll > len(lines)-viewHeight {
-		m.scroll = max(0, len(lines)-viewHeight)
-	}
-
-	end := m.scroll + viewHeight
-	if end > len(lines) {
-		end = len(lines)
-	}
-
-	for _, line := range lines[m.scroll:end] {
-		b.WriteString(line + "\n")
-	}
-
-	return b.String()
+	return strings.Join(rows, "\n")
 }
 
-func displayName(name, id string) string {
-	if name != "" {
-		return name
+// --- Listeners rendering ---
+
+func (m Model) renderListenersContent(maxWidth, maxHeight int) string {
+	if len(m.listeners) == 0 {
+		return shared.StyleHelp.Render("No listeners configured")
 	}
-	if len(id) > 12 {
-		return id[:12] + "..."
+
+	// Build pool name lookup
+	poolNames := make(map[string]string, len(m.pools))
+	for _, p := range m.pools {
+		poolNames[p.ID] = p.Name
 	}
-	return id
+
+	const gap = 2
+	sep := strings.Repeat(" ", gap)
+
+	nameW := len("Name")
+	for _, l := range m.listeners {
+		n := l.Name
+		if n == "" {
+			n = l.Protocol
+		}
+		if len(n) > nameW {
+			nameW = len(n)
+		}
+	}
+	if nameW > 20 {
+		nameW = 20
+	}
+
+	protoW := len("Protocol")
+	portW := len("Port")
+	for _, l := range m.listeners {
+		ps := fmt.Sprintf("%d", l.ProtocolPort)
+		if len(ps) > portW {
+			portW = len(ps)
+		}
+		if len(l.Protocol) > protoW {
+			protoW = len(l.Protocol)
+		}
+	}
+
+	poolW := maxWidth - nameW - protoW - portW - gap*3 - 2
+	if poolW < 8 {
+		poolW = 8
+	}
+
+	headerStyle := lipgloss.NewStyle().Foreground(shared.ColorMuted).Bold(true)
+	header := fmt.Sprintf("  %-*s%s%-*s%s%-*s%s%s",
+		nameW, "Name", sep, protoW, "Protocol", sep, portW, "Port", sep, "Default Pool")
+	headerLine := headerStyle.Render(header)
+
+	visibleLines := maxHeight - 1
+	if visibleLines < 1 {
+		visibleLines = 1
+	}
+
+
+
+	var lines []string
+	lines = append(lines, headerLine)
+
+	for i, l := range m.listeners {
+		if i < m.listenerScroll {
+			continue
+		}
+		if i >= m.listenerScroll+visibleLines {
+			break
+		}
+
+		selected := m.focus == focusListeners && i == m.listenerCursor
+		prefix := "  "
+		if selected {
+			prefix = "\u25b8 "
+		}
+
+		name := l.Name
+		if name == "" {
+			name = l.Protocol
+		}
+		if len(name) > nameW {
+			name = name[:nameW-1] + "\u2026"
+		}
+
+		pool := poolNames[l.DefaultPoolID]
+		if pool == "" && l.DefaultPoolID != "" {
+			pool = l.DefaultPoolID[:min(8, len(l.DefaultPoolID))] + "\u2026"
+		}
+		if pool == "" {
+			pool = "\u2014"
+		}
+		if len(pool) > poolW {
+			pool = pool[:poolW-1] + "\u2026"
+		}
+
+		line := fmt.Sprintf("%s%-*s%s%-*s%s%-*d%s%s",
+			prefix, nameW, name, sep, protoW, l.Protocol, sep, portW, l.ProtocolPort, sep, pool)
+
+		if selected {
+			line = selectedRowStyle.Render(line)
+		}
+		lines = append(lines, line)
+	}
+
+	return strings.Join(lines, "\n")
 }
+
+// --- Pools rendering ---
+
+func (m Model) renderPoolsContent(maxWidth, maxHeight int) string {
+	if len(m.pools) == 0 {
+		return shared.StyleHelp.Render("No pools configured")
+	}
+
+	nameW := len("Pool")
+	for _, p := range m.pools {
+		if len(p.Name) > nameW {
+			nameW = len(p.Name)
+		}
+	}
+	maxNameW := maxWidth - 2 - 14 // room for method + health indicator
+	if maxNameW < 8 {
+		maxNameW = 8
+	}
+	if nameW > maxNameW {
+		nameW = maxNameW
+	}
+
+	methodW := len("Method")
+	for _, p := range m.pools {
+		if len(p.LBMethod) > methodW {
+			methodW = len(p.LBMethod)
+		}
+	}
+	if methodW > 16 {
+		methodW = 16
+	}
+
+	headerStyle := lipgloss.NewStyle().Foreground(shared.ColorMuted).Bold(true)
+	header := fmt.Sprintf("  %-*s  %-*s  %s", nameW, "Pool", methodW, "Method", "Hlth")
+	headerLine := headerStyle.Render(header)
+
+	// Reserve lines for health monitor details when a monitor exists
+	monReserve := 0
+	if m.selectedPoolMonitor() != nil {
+		monReserve = 8 // title + blank + up to 6 detail lines
+	}
+
+	poolVisibleLines := maxHeight - 1 - monReserve
+	if poolVisibleLines < 1 {
+		poolVisibleLines = 1
+	}
+
+	var lines []string
+	lines = append(lines, headerLine)
+
+	for i, p := range m.pools {
+		if i < m.poolScroll {
+			continue
+		}
+		if i >= m.poolScroll+poolVisibleLines {
+			break
+		}
+
+		selected := m.focus == focusPools && i == m.poolCursor
+		prefix := "  "
+		if selected {
+			prefix = "\u25b8 "
+		}
+
+		name := p.Name
+		if len(name) > nameW {
+			name = name[:nameW-1] + "\u2026"
+		}
+
+		method := p.LBMethod
+		if len(method) > methodW {
+			method = method[:methodW-1] + "\u2026"
+		}
+
+		// Health monitor indicator
+		health := "\u2014"
+		if mon := m.monitors[p.MonitorID]; mon != nil {
+			health = mon.Type
+			if mon.Type == "HTTP" || mon.Type == "HTTPS" {
+				health = mon.Type + " " + mon.URLPath
+			}
+			// Truncate if too long
+			maxHW := maxWidth - nameW - methodW - 8
+			if maxHW < 4 {
+				maxHW = 4
+			}
+			if len(health) > maxHW {
+				health = health[:maxHW-1] + "\u2026"
+			}
+		}
+
+		line := fmt.Sprintf("%s%-*s  %-*s  %s",
+			prefix, nameW, name, methodW, method, health)
+
+		if selected {
+			line = selectedRowStyle.Render(line)
+		}
+		lines = append(lines, line)
+	}
+
+	// Show health monitor details for the selected pool
+	if mon := m.selectedPoolMonitor(); mon != nil {
+		lines = append(lines, "")
+		monStyle := lipgloss.NewStyle().Foreground(shared.ColorCyan)
+		labelStyle := lipgloss.NewStyle().Foreground(shared.ColorSecondary)
+		lines = append(lines, monStyle.Render("  \u2665 Health Monitor"))
+
+		details := []struct{ k, v string }{
+			{"Type", mon.Type},
+			{"Interval", fmt.Sprintf("%ds delay, %ds timeout", mon.Delay, mon.Timeout)},
+			{"Retries", fmt.Sprintf("%d up / %d down", mon.MaxRetries, mon.MaxRetriesDown)},
+		}
+		if mon.URLPath != "" {
+			details = append(details, struct{ k, v string }{"Path", mon.HTTPMethod + " " + mon.URLPath})
+		}
+		if mon.ExpectedCodes != "" {
+			details = append(details, struct{ k, v string }{"Expect", mon.ExpectedCodes})
+		}
+		if mon.OperatingStatus != "" {
+			details = append(details, struct{ k, v string }{"Status", shared.StatusIcon(mon.OperatingStatus) + mon.OperatingStatus})
+		}
+
+		remaining := monReserve - 2 // title + blank already added
+		for _, d := range details {
+			if remaining <= 0 {
+				break
+			}
+			lines = append(lines, fmt.Sprintf("    %s %s", labelStyle.Width(9).Render(d.k), d.v))
+			remaining--
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// --- Members rendering ---
+
+func (m Model) renderMembersContent(maxWidth, maxHeight int) string {
+	members := m.selectedPoolMembers()
+	if len(m.pools) == 0 {
+		return shared.StyleHelp.Render("No pools to show members for")
+	}
+	if len(members) == 0 {
+		return shared.StyleHelp.Render("No members in this pool")
+	}
+
+	const gap = 2
+	sep := strings.Repeat(" ", gap)
+
+	// Calculate column widths
+	addrW := len("Address")
+	for _, mem := range members {
+		addr := fmt.Sprintf("%s:%d", mem.Address, mem.ProtocolPort)
+		if len(addr) > addrW {
+			addrW = len(addr)
+		}
+	}
+	if addrW > 24 {
+		addrW = 24
+	}
+
+	nameW := len("Name")
+	for _, mem := range members {
+		if len(mem.Name) > nameW {
+			nameW = len(mem.Name)
+		}
+	}
+	maxNameW := maxWidth - addrW - 6 - 12 - gap*3 - 2 // weight(6) + status(12)
+	if maxNameW < 6 {
+		maxNameW = 6
+	}
+	if nameW > maxNameW {
+		nameW = maxNameW
+	}
+
+	headerStyle := lipgloss.NewStyle().Foreground(shared.ColorMuted).Bold(true)
+	header := fmt.Sprintf("  %-*s%s%-*s%s%-6s%s%s",
+		nameW, "Name", sep, addrW, "Address", sep, "Weight", sep, "Status")
+	headerLine := headerStyle.Render(header)
+
+	visibleLines := maxHeight - 1
+	if visibleLines < 1 {
+		visibleLines = 1
+	}
+
+
+
+	var lines []string
+	lines = append(lines, headerLine)
+
+	for i, mem := range members {
+		if i < m.memberScroll {
+			continue
+		}
+		if i >= m.memberScroll+visibleLines {
+			break
+		}
+
+		selected := m.focus == focusMembers && i == m.memberCursor
+		prefix := "  "
+		if selected {
+			prefix = "\u25b8 "
+		}
+
+		name := mem.Name
+		if name == "" {
+			name = "\u2014"
+		}
+		if len(name) > nameW {
+			name = name[:nameW-1] + "\u2026"
+		}
+
+		addr := fmt.Sprintf("%s:%d", mem.Address, mem.ProtocolPort)
+		if len(addr) > addrW {
+			addr = addr[:addrW-1] + "\u2026"
+		}
+
+		weight := fmt.Sprintf("%d", mem.Weight)
+		status := shared.StatusIcon(mem.OperatingStatus) + mem.OperatingStatus
+		statusStyle := memberStatusStyle(mem.OperatingStatus)
+
+		line := fmt.Sprintf("%s%-*s%s%-*s%s%-6s%s%s",
+			prefix, nameW, name, sep, addrW, addr, sep, weight, sep,
+			statusStyle.Render(status))
+
+		if selected {
+			line = selectedRowStyle.Render(line)
+		}
+		lines = append(lines, line)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// --- Action bar ---
+
+func (m Model) renderActionBar() string {
+	if m.lb == nil {
+		return ""
+	}
+
+	keyStyle := lipgloss.NewStyle().
+		Foreground(shared.ColorHighlight).
+		Background(shared.ColorSecondary).
+		Bold(true).Padding(0, 0)
+	labelStyle := lipgloss.NewStyle().Foreground(shared.ColorFg)
+
+	type btn struct{ key, label string }
+	buttons := []btn{
+		{"^d", "Delete LB"},
+		{"tab", "Switch Pane"},
+		{"esc", "Back"},
+	}
+
+	var parts []string
+	totalLen := 0
+	maxWidth := m.width - 4
+
+	for _, b := range buttons {
+		part := keyStyle.Render("["+b.key+"]") + labelStyle.Render(b.label)
+		partLen := len("["+b.key+"]") + len(b.label) + 1
+		if totalLen+partLen > maxWidth && len(parts) > 0 {
+			break
+		}
+		parts = append(parts, part)
+		totalLen += partLen
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+	return " " + strings.Join(parts, " ")
+}
+
+// --- Style helpers ---
 
 func provStatusStyleFn(status string) lipgloss.Style {
 	var fg color.Color = shared.ColorFg
@@ -311,9 +980,15 @@ func memberStatusStyle(status string) lipgloss.Style {
 		fg = shared.ColorSuccess
 	case "OFFLINE", "ERROR":
 		fg = shared.ColorError
+	case "NO_MONITOR":
+		fg = shared.ColorMuted
+	case "DRAINING":
+		fg = shared.ColorWarning
 	}
 	return lipgloss.NewStyle().Foreground(fg)
 }
+
+// --- Data fetching ---
 
 func (m Model) fetchDetail() tea.Cmd {
 	client := m.client
@@ -337,12 +1012,20 @@ func (m Model) fetchDetail() tea.Cmd {
 		}
 
 		members := make(map[string][]loadbalancer.Member)
+		mons := make(map[string]*loadbalancer.HealthMonitor)
+
 		for _, p := range pls {
 			mems, err := loadbalancer.ListMembers(ctx, client, p.ID)
-			if err != nil {
-				continue // best effort
+			if err == nil {
+				members[p.ID] = mems
 			}
-			members[p.ID] = mems
+
+			if p.MonitorID != "" {
+				mon, err := loadbalancer.GetHealthMonitor(ctx, client, p.MonitorID)
+				if err == nil {
+					mons[p.MonitorID] = mon
+				}
+			}
 		}
 
 		return lbDetailLoadedMsg{
@@ -350,6 +1033,7 @@ func (m Model) fetchDetail() tea.Cmd {
 			listeners: lstnrs,
 			pools:     pls,
 			members:   members,
+			monitors:  mons,
 		}
 	}
 }
@@ -374,5 +1058,14 @@ func (m *Model) SetSize(w, h int) {
 
 // Hints returns key hints for the status bar.
 func (m Model) Hints() string {
-	return "↑↓ scroll • ^d delete • R refresh • esc back • ? help"
+	switch m.focus {
+	case focusListeners:
+		return "\u2191\u2193 navigate \u2022 tab switch pane \u2022 ^d delete \u2022 R refresh \u2022 esc back \u2022 ? help"
+	case focusPools:
+		return "\u2191\u2193 select pool \u2022 tab switch pane \u2022 ^d delete \u2022 R refresh \u2022 esc back \u2022 ? help"
+	case focusMembers:
+		return "\u2191\u2193 navigate members \u2022 tab switch pane \u2022 ^d delete \u2022 R refresh \u2022 esc back \u2022 ? help"
+	default:
+		return "tab switch pane \u2022 ^d delete \u2022 R refresh \u2022 esc back \u2022 ? help"
+	}
 }


### PR DESCRIPTION
## Summary
- Replace simple scrollable LB detail with a rich 4-pane layout inspired by the security groups view
- Add health monitor data model and API support (HealthMonitor struct, GetHealthMonitor, MonitorID on Pool)
- 4 panes: Info (metadata/statuses), Listeners (protocol/port/pool), Pools (method/health indicator with inline monitor details), Members (per-pool address/weight/status)
- Tab/Shift+Tab focus cycling, per-pane cursor/scroll, responsive wide/narrow layout

## Test plan
- [ ] Open a load balancer detail view — verify 4 panes render correctly
- [ ] Tab through panes — focus highlight cycles Info -> Listeners -> Pools -> Members
- [ ] Navigate pools with arrow keys — members panel updates to show selected pool's members
- [ ] Pool with health monitor — verify inline health check details appear (type, interval, retries, path, codes)
- [ ] Pool without health monitor — verify dash shown in health column, no inline details
- [ ] Narrow terminal (<80 cols) — verify vertical stack layout
- [ ] Ctrl+D delete — verify delete confirmation still works from detail view
- [ ] Esc — verify navigation back to LB list