### PR TITLE
feat: attach/detach volumes to servers

### DIFF
--- a/src/internal/app/actions_resource.go
+++ b/src/internal/app/actions_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/larkly/lazystack/internal/ui/routerdetail"
 	"github.com/larkly/lazystack/internal/ui/serverpicker"
 	"github.com/larkly/lazystack/internal/ui/subnetpicker"
+	"github.com/larkly/lazystack/internal/ui/volumepicker"
 	"github.com/larkly/lazystack/internal/ui/sgcreate"
 	"github.com/larkly/lazystack/internal/ui/sgrulecreate"
 	"github.com/larkly/lazystack/internal/ui/volumecreate"
@@ -71,8 +72,19 @@ func (m Model) openVolumeDeleteConfirm() (Model, tea.Cmd) {
 }
 
 func (m Model) openVolumeAttach() (Model, tea.Cmd) {
-	id := m.volumeDetail.SelectedVolumeID()
-	name := m.volumeDetail.SelectedVolumeName()
+	var id, name string
+	switch m.view {
+	case viewVolumeDetail:
+		id = m.volumeDetail.SelectedVolumeID()
+		name = m.volumeDetail.SelectedVolumeName()
+	case viewVolumeList:
+		if v := m.volumeList.SelectedVolume(); v != nil {
+			id, name = v.ID, v.Name
+			if name == "" {
+				name = id
+			}
+		}
+	}
 	if id == "" {
 		return m, nil
 	}
@@ -82,17 +94,59 @@ func (m Model) openVolumeAttach() (Model, tea.Cmd) {
 }
 
 func (m Model) openVolumeDetach() (Model, tea.Cmd) {
-	if m.view != viewVolumeDetail {
-		return m, nil
+	var id, name string
+	switch m.view {
+	case viewVolumeDetail:
+		id = m.volumeDetail.SelectedVolumeID()
+		name = m.volumeDetail.SelectedVolumeName()
+	case viewVolumeList:
+		if v := m.volumeList.SelectedVolume(); v != nil {
+			if v.AttachedServerID == "" {
+				return m, nil
+			}
+			id, name = v.ID, v.Name
+			if name == "" {
+				name = id
+			}
+		}
 	}
-	id := m.volumeDetail.SelectedVolumeID()
-	name := m.volumeDetail.SelectedVolumeName()
 	if id == "" {
 		return m, nil
 	}
 	m.confirm = modal.NewConfirm("detach_volume", id, name)
 	m.confirm.Title = "Detach Volume"
 	m.confirm.Body = fmt.Sprintf("Are you sure you want to detach volume %q?", name)
+	m.confirm.SetSize(m.width, m.height)
+	m.activeModal = modalConfirm
+	return m, nil
+}
+
+func (m Model) openServerVolumeAttach() (Model, tea.Cmd) {
+	if m.view != viewServerDetail {
+		return m, nil
+	}
+	serverID := m.serverDetail.ServerID()
+	serverName := m.serverDetail.ServerName()
+	if serverID == "" {
+		return m, nil
+	}
+	m.volumePicker = volumepicker.New(m.client.Compute, m.client.BlockStorage, serverID, serverName)
+	m.volumePicker.SetSize(m.width, m.height)
+	return m, m.volumePicker.Init()
+}
+
+func (m Model) openServerVolumeDetach() (Model, tea.Cmd) {
+	if m.view != viewServerDetail {
+		return m, nil
+	}
+	volID := m.serverDetail.SelectedVolumeID()
+	volName := m.serverDetail.SelectedVolumeName()
+	if volID == "" {
+		return m, nil
+	}
+	m.confirm = modal.NewConfirm("detach_volume", volID, volName)
+	m.confirm.Title = "Detach Volume"
+	m.confirm.Body = fmt.Sprintf("Are you sure you want to detach volume %q from server %q?", volName, m.serverDetail.ServerName())
 	m.confirm.SetSize(m.width, m.height)
 	m.activeModal = modalConfirm
 	return m, nil

--- a/src/internal/app/app.go
+++ b/src/internal/app/app.go
@@ -40,6 +40,7 @@ import (
 	"github.com/larkly/lazystack/internal/ui/sgcreate"
 	"github.com/larkly/lazystack/internal/ui/sgrulecreate"
 	"github.com/larkly/lazystack/internal/ui/serverpicker"
+	"github.com/larkly/lazystack/internal/ui/volumepicker"
 	"github.com/larkly/lazystack/internal/ui/serverdetail"
 	"github.com/larkly/lazystack/internal/ui/serverrename"
 	"github.com/larkly/lazystack/internal/ui/serverrebuild"
@@ -127,6 +128,7 @@ type Model struct {
 	consoleURL      consoleurl.Model
 	fipPicker     fippicker.Model
 	serverPicker  serverpicker.Model
+	volumePicker  volumepicker.Model
 	sgCreate       sgcreate.Model
 	networkCreate  networkcreate.Model
 	subnetCreate   subnetcreate.Model
@@ -302,6 +304,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.consoleURL.SetSize(m.width, m.height)
 		m.fipPicker.SetSize(m.width, m.height)
 		m.serverPicker.SetSize(m.width, m.height)
+		m.volumePicker.SetSize(m.width, m.height)
 		m.sgCreate.SetSize(m.width, m.height)
 		m.sgRuleCreate.SetSize(m.width, m.height)
 		m.networkCreate.SetSize(m.width, m.height)
@@ -412,6 +415,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.serverPicker.Active {
 			var cmd tea.Cmd
 			m.serverPicker, cmd = m.serverPicker.Update(msg)
+			return m, cmd
+		}
+
+		// Volume picker modal intercepts all keys when active
+		if m.volumePicker.Active {
+			var cmd tea.Cmd
+			m.volumePicker, cmd = m.volumePicker.Update(msg)
 			return m, cmd
 		}
 
@@ -549,6 +559,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m.openActionLog()
 			}
 
+			// Volume attach/detach from server detail volumes pane
+			if m.view == viewServerDetail && m.serverDetail.FocusedOnVolumes() {
+				if key.Matches(msg, shared.Keys.Attach) {
+					return m.openServerVolumeAttach()
+				}
+				if key.Matches(msg, shared.Keys.Detach) {
+					return m.openServerVolumeDetach()
+				}
+			}
+
 			// Block all mutating actions on locked servers
 			if m.isSelectedServerLocked() && key.Matches(msg,
 				shared.Keys.Delete, shared.Keys.Reboot, shared.Keys.HardReboot,
@@ -615,7 +635,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		// Volume list: Enter to open detail, ctrl+d to delete, ctrl+n to create
+		// Volume list: Enter to open detail, ctrl+d to delete, ctrl+n to create, ctrl+a attach, ctrl+t detach
 		if m.view == viewVolumeList {
 			if key.Matches(msg, shared.Keys.Enter) {
 				return m.openVolumeDetail()
@@ -625,6 +645,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if key.Matches(msg, shared.Keys.Create) {
 				return m.openVolumeCreate()
+			}
+			if key.Matches(msg, shared.Keys.Attach) {
+				return m.openVolumeAttach()
+			}
+			if key.Matches(msg, shared.Keys.Detach) {
+				return m.openVolumeDetach()
 			}
 		}
 
@@ -1160,6 +1186,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.serverPicker.Active {
 			var cmd tea.Cmd
 			m.serverPicker, cmd = m.serverPicker.Update(msg)
+			return m, tea.Batch(viewCmd, cmd)
+		}
+		if m.volumePicker.Active {
+			var cmd tea.Cmd
+			m.volumePicker, cmd = m.volumePicker.Update(msg)
 			return m, tea.Batch(viewCmd, cmd)
 		}
 		if m.routerCreate.Active {

--- a/src/internal/app/render.go
+++ b/src/internal/app/render.go
@@ -96,6 +96,9 @@ func (m Model) viewContent() string {
 	if m.serverPicker.Active {
 		return m.serverPicker.View()
 	}
+	if m.volumePicker.Active {
+		return m.volumePicker.View()
+	}
 	if m.routerCreate.Active {
 		return m.routerCreate.View()
 	}

--- a/src/internal/ui/serverdetail/serverdetail.go
+++ b/src/internal/ui/serverdetail/serverdetail.go
@@ -159,6 +159,34 @@ func (m Model) ServerName() string {
 	return m.serverID
 }
 
+// SelectedVolumeID returns the volume ID under the cursor in the volumes pane.
+func (m Model) SelectedVolumeID() string {
+	if m.server == nil || len(m.server.VolAttach) == 0 {
+		return ""
+	}
+	if m.volumeCursor >= 0 && m.volumeCursor < len(m.server.VolAttach) {
+		return m.server.VolAttach[m.volumeCursor].ID
+	}
+	return ""
+}
+
+// SelectedVolumeName returns the name of the volume under the cursor.
+func (m Model) SelectedVolumeName() string {
+	id := m.SelectedVolumeID()
+	if id == "" {
+		return ""
+	}
+	if vol, ok := m.volumeInfo[id]; ok && vol.Name != "" {
+		return vol.Name
+	}
+	return id
+}
+
+// FocusedOnVolumes returns true when the volumes pane has focus.
+func (m Model) FocusedOnVolumes() bool {
+	return m.focus == focusVolumes
+}
+
 // ServerStatus returns the current server status.
 func (m Model) ServerStatus() string {
 	if m.server != nil {
@@ -1365,7 +1393,7 @@ func (m Model) Hints() string {
 	case focusInterfaces:
 		return "\u2191\u2193 scroll interfaces \u2022 " + base
 	case focusVolumes:
-		return "\u2191\u2193 select \u2022 enter detail \u2022 " + base
+		return "\u2191\u2193 select \u2022 enter detail \u2022 ^a attach \u2022 ^t detach \u2022 " + base
 	case focusConsole:
 		return "\u2191\u2193 scroll log \u2022 g top \u2022 G bottom \u2022 " + base
 	case focusActions:

--- a/src/internal/ui/volumelist/volumelist.go
+++ b/src/internal/ui/volumelist/volumelist.go
@@ -665,5 +665,5 @@ func (m *Model) applyHighlight() {
 
 // Hints returns key hints.
 func (m Model) Hints() string {
-	return "↑↓ navigate • enter detail • ^n create • ^d delete • R refresh • 1-5/←→ switch tab • ? help"
+	return "↑↓ navigate • enter detail • ^n create • ^d delete • ^a attach • ^t detach • R refresh • 1-5/←→ switch tab • ? help"
 }

--- a/src/internal/ui/volumepicker/volumepicker.go
+++ b/src/internal/ui/volumepicker/volumepicker.go
@@ -1,0 +1,285 @@
+package volumepicker
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/larkly/lazystack/internal/shared"
+	"github.com/larkly/lazystack/internal/volume"
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/spinner"
+	"charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/gophercloud/gophercloud/v2"
+)
+
+type volumesLoadedMsg struct{ volumes []volume.Volume }
+type fetchErrMsg struct{ err error }
+type attachDoneMsg struct{ serverName, volumeName string }
+type attachErrMsg struct{ err error }
+
+// Model is the volume picker modal for attaching a volume to a server.
+type Model struct {
+	Active        bool
+	computeClient *gophercloud.ServiceClient
+	blockClient   *gophercloud.ServiceClient
+	serverID      string
+	serverName    string
+	volumes       []volume.Volume
+	filtered      []volume.Volume
+	cursor        int
+	loading       bool
+	submitting    bool
+	spinner       spinner.Model
+	filter        string
+	width         int
+	height        int
+	err           string
+	scrollOff     int
+}
+
+// New creates a volume picker for attaching a volume to the given server.
+func New(computeClient, blockClient *gophercloud.ServiceClient, serverID, serverName string) Model {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	return Model{
+		Active:        true,
+		computeClient: computeClient,
+		blockClient:   blockClient,
+		serverID:      serverID,
+		serverName:    serverName,
+		loading:       true,
+		spinner:       s,
+	}
+}
+
+// Init fetches available volumes.
+func (m Model) Init() tea.Cmd {
+	return tea.Batch(m.spinner.Tick, m.fetchVolumes())
+}
+
+// Update handles messages.
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case volumesLoadedMsg:
+		m.loading = false
+		m.volumes = msg.volumes
+		m.applyFilter()
+		return m, nil
+
+	case fetchErrMsg:
+		m.loading = false
+		m.err = msg.err.Error()
+		return m, nil
+
+	case attachDoneMsg:
+		m.submitting = false
+		m.Active = false
+		return m, func() tea.Msg {
+			return shared.ResourceActionMsg{
+				Action: "Attached volume",
+				Name:   fmt.Sprintf("%s → %s", msg.volumeName, msg.serverName),
+			}
+		}
+
+	case attachErrMsg:
+		m.submitting = false
+		m.err = msg.err.Error()
+		return m, nil
+
+	case spinner.TickMsg:
+		if m.loading || m.submitting {
+			var cmd tea.Cmd
+			m.spinner, cmd = m.spinner.Update(msg)
+			return m, cmd
+		}
+		return m, nil
+
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		if m.loading || m.submitting {
+			return m, nil
+		}
+		switch {
+		case key.Matches(msg, shared.Keys.Back):
+			m.Active = false
+			return m, nil
+		case key.Matches(msg, shared.Keys.Up):
+			if m.cursor > 0 {
+				m.cursor--
+				m.ensureVisible()
+			}
+		case key.Matches(msg, shared.Keys.Down):
+			if m.cursor < len(m.filtered)-1 {
+				m.cursor++
+				m.ensureVisible()
+			}
+		case key.Matches(msg, shared.Keys.Enter):
+			if len(m.filtered) > 0 && m.cursor < len(m.filtered) {
+				vol := m.filtered[m.cursor]
+				m.submitting = true
+				return m, tea.Batch(m.spinner.Tick, m.attachVolume(vol))
+			}
+		default:
+			s := msg.String()
+			if s == "backspace" {
+				if len(m.filter) > 0 {
+					m.filter = m.filter[:len(m.filter)-1]
+					m.cursor = 0
+					m.scrollOff = 0
+					m.applyFilter()
+				}
+			} else if len(s) == 1 && s[0] >= 32 && s[0] < 127 {
+				m.filter += s
+				m.cursor = 0
+				m.scrollOff = 0
+				m.applyFilter()
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m *Model) applyFilter() {
+	if m.filter == "" {
+		m.filtered = m.volumes
+		return
+	}
+	q := strings.ToLower(m.filter)
+	m.filtered = nil
+	for _, vol := range m.volumes {
+		if strings.Contains(strings.ToLower(vol.Name), q) ||
+			strings.Contains(strings.ToLower(vol.ID), q) {
+			m.filtered = append(m.filtered, vol)
+		}
+	}
+}
+
+func (m *Model) ensureVisible() {
+	th := m.listHeight()
+	if m.cursor < m.scrollOff {
+		m.scrollOff = m.cursor
+	}
+	if m.cursor >= m.scrollOff+th {
+		m.scrollOff = m.cursor - th + 1
+	}
+}
+
+func (m Model) listHeight() int {
+	h := m.height - 14
+	if h < 3 {
+		h = 3
+	}
+	return h
+}
+
+// View renders the volume picker modal.
+func (m Model) View() string {
+	title := shared.StyleModalTitle.Render("Attach Volume to " + m.serverName)
+
+	var body string
+	if m.loading {
+		body = m.spinner.View() + " Loading volumes..."
+	} else if m.submitting {
+		body = m.spinner.View() + " Attaching..."
+	} else if m.err != "" {
+		body = lipgloss.NewStyle().Foreground(shared.ColorError).Render("Error: " + m.err)
+		body += "\n\n" + shared.StyleHelp.Render("esc to close")
+	} else if len(m.filtered) == 0 {
+		body = shared.StyleHelp.Render("No available volumes found")
+		body += "\n\n" + shared.StyleHelp.Render("esc to close")
+	} else {
+		var lines []string
+		th := m.listHeight()
+		end := m.scrollOff + th
+		if end > len(m.filtered) {
+			end = len(m.filtered)
+		}
+
+		for i := m.scrollOff; i < end; i++ {
+			vol := m.filtered[i]
+			cursor := "  "
+			if i == m.cursor {
+				cursor = "▸ "
+			}
+			style := lipgloss.NewStyle().Foreground(shared.ColorFg)
+			if i == m.cursor {
+				style = style.Foreground(shared.ColorHighlight).Bold(true)
+			}
+			mutedStyle := lipgloss.NewStyle().Foreground(shared.ColorMuted)
+
+			name := vol.Name
+			if name == "" {
+				name = vol.ID[:12]
+			}
+			detail := mutedStyle.Render(fmt.Sprintf(" %dGB", vol.Size))
+			if vol.VolumeType != "" {
+				detail += mutedStyle.Render(" • " + vol.VolumeType)
+			}
+			line := cursor + style.Render(name) + detail
+			lines = append(lines, line)
+		}
+		body = strings.Join(lines, "\n")
+
+		filterHint := ""
+		if m.filter != "" {
+			filterHint = fmt.Sprintf("\n\nFilter: %s", m.filter)
+		}
+		body += filterHint
+		body += "\n\n" + shared.StyleHelp.Render("↑↓ navigate • enter select • type to filter • esc cancel")
+	}
+
+	content := title + "\n\n" + body
+	modalWidth := 60
+	if m.width > 0 && m.width < 70 {
+		modalWidth = m.width - 6
+	}
+	box := shared.StyleModal.Width(modalWidth).Render(content)
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
+}
+
+// SetSize updates dimensions.
+func (m *Model) SetSize(w, h int) {
+	m.width = w
+	m.height = h
+}
+
+func (m Model) fetchVolumes() tea.Cmd {
+	client := m.blockClient
+	return func() tea.Msg {
+		vols, err := volume.ListVolumes(context.Background(), client)
+		if err != nil {
+			return fetchErrMsg{err: err}
+		}
+		var available []volume.Volume
+		for _, v := range vols {
+			if v.Status == "available" && v.AttachedServerID == "" {
+				available = append(available, v)
+			}
+		}
+		return volumesLoadedMsg{volumes: available}
+	}
+}
+
+func (m Model) attachVolume(vol volume.Volume) tea.Cmd {
+	client := m.computeClient
+	serverID := m.serverID
+	serverName := m.serverName
+	volumeID := vol.ID
+	volumeName := vol.Name
+	if volumeName == "" {
+		volumeName = vol.ID[:12]
+	}
+	return func() tea.Msg {
+		err := volume.AttachVolume(context.Background(), client, serverID, volumeID)
+		if err != nil {
+			return attachErrMsg{err: err}
+		}
+		return attachDoneMsg{serverName: serverName, volumeName: volumeName}
+	}
+}


### PR DESCRIPTION
## Summary
- Add volume picker modal for attaching volumes from server detail (Ctrl+A on volumes pane)
- Add detach action from server detail volumes pane (Ctrl+T on selected volume)
- Wire attach/detach keybindings in volume list view (Ctrl+A / Ctrl+T)
- Context-aware Ctrl+A: volume attach on volumes pane, FIP association on other panes

Closes #49

## Test plan
- [ ] Server detail → focus volumes pane → Ctrl+A opens volume picker → select → volume attaches
- [ ] Server detail → focus volumes pane → cursor on volume → Ctrl+T → confirm → volume detaches
- [ ] Volume list → cursor on available volume → Ctrl+A → server picker → select → attaches
- [ ] Volume list → cursor on attached volume → Ctrl+T → confirm → detaches
- [ ] Volume detail → Ctrl+A / Ctrl+T still work (existing behavior preserved)
- [ ] Server detail → non-volumes pane → Ctrl+A still does FIP association
- [ ] Locked server → volumes pane → Ctrl+A still works (volume op, not server mutation)