### PR TITLE
fix: pre-release punch list from v0.9 code review

### DIFF
--- a/src/internal/quota/quota.go
+++ b/src/internal/quota/quota.go
@@ -18,15 +18,27 @@ type QuotaUsage struct {
 	Limit    int
 }
 
+// requireProjectID guards against empty project IDs, which would otherwise
+// produce a malformed /os-quota-sets//detail URL at the OpenStack API layer.
+func requireProjectID(projectID string) error {
+	if projectID == "" {
+		return fmt.Errorf("projectID is required")
+	}
+	return nil
+}
+
 // GetComputeQuotas returns compute quota usage.
 func GetComputeQuotas(ctx context.Context, client *gophercloud.ServiceClient, projectID string) ([]QuotaUsage, error) {
 	shared.Debugf("[quota] GetComputeQuotas: start projectID=%s", projectID)
+	if err := requireProjectID(projectID); err != nil {
+		shared.Debugf("[quota] GetComputeQuotas: %v", err)
+		return nil, err
+	}
 	detail, err := computequotas.GetDetail(ctx, client, projectID).Extract()
 	if err != nil {
 		shared.Debugf("[quota] GetComputeQuotas: error: %v", err)
 		return nil, fmt.Errorf("compute quotas: %w", err)
 	}
-	shared.Debugf("[quota] GetComputeQuotas: success count=5")
 	return []QuotaUsage{
 		{Resource: "Instances", Used: detail.Instances.InUse, Limit: detail.Instances.Limit},
 		{Resource: "Cores", Used: detail.Cores.InUse, Limit: detail.Cores.Limit},
@@ -39,12 +51,15 @@ func GetComputeQuotas(ctx context.Context, client *gophercloud.ServiceClient, pr
 // GetNetworkQuotas returns network quota usage.
 func GetNetworkQuotas(ctx context.Context, client *gophercloud.ServiceClient, projectID string) ([]QuotaUsage, error) {
 	shared.Debugf("[quota] GetNetworkQuotas: start projectID=%s", projectID)
+	if err := requireProjectID(projectID); err != nil {
+		shared.Debugf("[quota] GetNetworkQuotas: %v", err)
+		return nil, err
+	}
 	detail, err := networkquotas.GetDetail(ctx, client, projectID).Extract()
 	if err != nil {
 		shared.Debugf("[quota] GetNetworkQuotas: error: %v", err)
 		return nil, fmt.Errorf("network quotas: %w", err)
 	}
-	shared.Debugf("[quota] GetNetworkQuotas: success count=6")
 	return []QuotaUsage{
 		{Resource: "Floating IPs", Used: detail.FloatingIP.Used, Limit: detail.FloatingIP.Limit},
 		{Resource: "Networks", Used: detail.Network.Used, Limit: detail.Network.Limit},
@@ -58,12 +73,15 @@ func GetNetworkQuotas(ctx context.Context, client *gophercloud.ServiceClient, pr
 // GetVolumeQuotas returns block storage quota usage.
 func GetVolumeQuotas(ctx context.Context, client *gophercloud.ServiceClient, projectID string) ([]QuotaUsage, error) {
 	shared.Debugf("[quota] GetVolumeQuotas: start projectID=%s", projectID)
+	if err := requireProjectID(projectID); err != nil {
+		shared.Debugf("[quota] GetVolumeQuotas: %v", err)
+		return nil, err
+	}
 	usage, err := bsquotas.GetUsage(ctx, client, projectID).Extract()
 	if err != nil {
 		shared.Debugf("[quota] GetVolumeQuotas: error: %v", err)
 		return nil, fmt.Errorf("volume quotas: %w", err)
 	}
-	shared.Debugf("[quota] GetVolumeQuotas: success count=4")
 	return []QuotaUsage{
 		{Resource: "Volumes", Used: usage.Volumes.InUse, Limit: usage.Volumes.Limit},
 		{Resource: "Gigabytes", Used: usage.Gigabytes.InUse, Limit: usage.Gigabytes.Limit},

--- a/src/internal/shared/debug.go
+++ b/src/internal/shared/debug.go
@@ -26,7 +26,7 @@ func EnableDebug() error {
 		return err
 	}
 	path := filepath.Join(dir, "debug.log")
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}

--- a/src/internal/shared/errors.go
+++ b/src/internal/shared/errors.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 )
 
-var urlPattern = regexp.MustCompile(`https?://[^\\s\"']+`)
+var urlPattern = regexp.MustCompile(`https?://[^\s"']+`)
 
 // Network error patterns to detect connectivity issues.
 var networkPatterns = []string{"timeout", "connection refused", "dial", "network"}
@@ -108,7 +108,7 @@ func ParseError(err error) *ParsedError {
 	sanitized := urlPattern.ReplaceAllString(raw, "[endpoint]")
 	return &ParsedError{
 		FriendlyMessage: sanitized,
-		RawError:        urlPattern.ReplaceAllString(raw, "[endpoint]"),
+		RawError:        sanitized,
 		HTTPStatusCode:  0,
 		Category:        "unknown",
 	}

--- a/src/internal/shared/errors_test.go
+++ b/src/internal/shared/errors_test.go
@@ -179,6 +179,43 @@ func TestParseError_URLSanitization(t *testing.T) {
 	}
 }
 
+// Test that text surrounding a URL is preserved after sanitization.
+// Regression: a broken regex (`[^\\s\"']+` in a raw string) greedily consumed
+// past whitespace and mangled the text following the URL.
+func TestParseError_PreservesTextAfterURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantSub string
+	}{
+		{
+			name:    "keystone auth error with trailing text",
+			input:   "Got 401 from https://keystone.foo.com:5000/v3/auth/tokens when authenticating user",
+			wantSub: "when authenticating user",
+		},
+		{
+			name:    "network reach error with trailing text",
+			input:   "failed to reach https://network.example.com:9696 because the server is down",
+			wantSub: "because the server is down",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed := ParseError(errors.New(tc.input))
+			if !strings.Contains(parsed.RawError, tc.wantSub) {
+				t.Errorf("text after URL lost: got RawError=%q, want to contain %q",
+					parsed.RawError, tc.wantSub)
+			}
+			if strings.Contains(parsed.RawError, "https://") {
+				t.Errorf("URL not sanitized: %q", parsed.RawError)
+			}
+			if !strings.Contains(parsed.RawError, "[endpoint]") {
+				t.Errorf("expected [endpoint] replacement: %q", parsed.RawError)
+			}
+		})
+	}
+}
+
 // Test nil error handling.
 func TestParseError_Nil(t *testing.T) {
 	parsed := ParseError(nil)

--- a/src/internal/ui/lbview/lbview.go
+++ b/src/internal/ui/lbview/lbview.go
@@ -706,7 +706,7 @@ func (m Model) shouldRefreshDetail() (Model, bool) {
 	var mode string
 
 	switch {
-	case hasPrefixAny(lb.ProvisioningStatus, "PENDING_CREATE", "PENDING_UPDATE", "PENDING_DELETE"):
+	case strings.HasPrefix(lb.ProvisioningStatus, "PENDING_"):
 		interval = 2 * time.Second
 		mode = "fast"
 	case strings.HasPrefix(lb.OperatingStatus, "ERROR") || strings.HasPrefix(lb.OperatingStatus, "DEGRADED"):
@@ -729,27 +729,12 @@ func (m Model) shouldRefreshDetail() (Model, bool) {
 		}
 	}
 
-	// Cap at 30s
-	if interval > 30*time.Second {
-		interval = 30 * time.Second
-		mode = "capped"
-	}
-
 	m.pollMode = mode
 	m.detailRefreshInterval = interval
 	if m.lastDetailFetch.IsZero() || time.Since(m.lastDetailFetch) >= interval {
 		return m, true
 	}
 	return m, false
-}
-
-func hasPrefixAny(s string, prefix string, prefixes ...string) bool {
-	for _, p := range append([]string{prefix}, prefixes...) {
-		if strings.HasPrefix(s, p) {
-			return true
-		}
-	}
-	return false
 }
 
 // --- Filter/search ---


### PR DESCRIPTION
## Summary

Pre-release code review of changes since `v0.8.0` surfaced one critical shipping regression and a handful of correctness / safety / simplification fixes. This PR lands the must-fix punch list so the next tag ships clean.

## Changes

1. **fix(errors): repair broken URL-sanitization regex** — `[^\\s\"']+` in a raw string was evaluating to a class that did NOT exclude whitespace, so URL matches greedily consumed past spaces and mangled every error-modal message containing a URL. Fixed to `[^\s"']+`, deduped the double `ReplaceAllString` in the unknown-category fallback, added a regression test asserting text after a URL is preserved.
2. **fix(debug): restrict debug log to 0o600** — with the comprehensive debug logging added in `fb17d06`, the log now records endpoints, project/server IDs, IPs, key paths, and error payloads. `0o644` was readable by any local user on multi-user hosts.
3. **fix(quota): guard empty projectID at package boundary** — `e327ebe` fixed this in the UI layer; this adds a `requireProjectID` guard inside the package so future callers can't re-trigger the malformed `/os-quota-sets//detail` URL. Also drops three tautological `count=N` success logs (hardcoded to slice length, zero diagnostic value).
4. **refactor(lb): simplify PENDING check and remove unreachable cap** — three `PENDING_*` cases collapse to `strings.HasPrefix(..., "PENDING_")`, and the 30s cap block is removed because the switch produces a max of 15s so `"capped"` was unreachable.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` full suite passes
- [x] `TestParseError_PreservesTextAfterURL` (new) passes; existing `TestParseError_URLSanitization` still passes
- [ ] Manual: trigger a network error and verify the error modal's raw (`d`) view keeps surrounding text intact
- [ ] Manual: `LAZYSTACK_DEBUG=1 ./lazystack` then `stat -c '%a' ~/.cache/lazystack/debug.log` → expect `600`
- [ ] Manual: open a load balancer detail view and confirm adaptive polling still cycles fast/medium/slow