### PR TITLE
feat(serverlist): content-aware adaptive column widths

### DIFF
--- a/docs/superpowers/specs/2026-04-17-serverlist-adaptive-columns-design.md
+++ b/docs/superpowers/specs/2026-04-17-serverlist-adaptive-columns-design.md
@@ -1,0 +1,93 @@
+# Server List Adaptive Columns
+
+## Problem
+
+The server list column layout wastes space on IPv6 at the expense of Name and Status:
+
+- `IPv6` has `Flex: 4` — 31% of all growth weight. When IPv6 addresses are short (or the network prefix dominates), the column grows far beyond what its content needs, leaving visible dead space before the next column.
+- `Name` has `MinWidth: 10, Flex: 2`. Server names are a primary identifier but can be clipped to 10 chars on narrower terminals.
+- `Status` has `MinWidth: 20, Flex: 0` — fixed. `■ SHELVED_OFFLOADED/SHUTDOWN` (28 display cols) gets clipped even on wide terminals.
+- Reaching a layout where all info is visible without truncation requires ~300 cols of terminal width.
+
+## Goals
+
+1. Server Name visible to at least 20 chars even on narrow terminals.
+2. Status fits the common case (`■ ACTIVE/RUNNING`, 16 cols) without waste, and grows toward the longest combo when space allows.
+3. IPv6 no longer consumes the bulk of the flex budget; truncates earlier when long.
+4. When IPv6 is truncated, show the host suffix (differs per server) rather than the shared network prefix.
+
+## Non-goals
+
+- Data-driven column sizing (sizing to the longest *actual* value in the current server list). Considered but deferred; out of scope for this change.
+- Changes to other list views (router, network, volume, etc.) — those don't share `columns.go`.
+- Changes to column order, visibility priorities, or the general `ComputeWidths` algorithm.
+
+## Changes
+
+### 1. `DefaultColumns` in [columns.go:20-32](src/internal/ui/serverlist/columns.go:20)
+
+| Column | MinWidth | Flex | Priority |
+|---|---|---|---|
+| Name | 10 → **20** | 2 → **4** | 0 |
+| Status | 20 → **16** | 0 → **1** | 0 |
+| IPv4 | 12 | 1 | 1 |
+| IPv6 | 20 → **15** | 4 → **1** | 5 |
+| Floating IP | 12 | 1 | 3 |
+| Flavor | 10 | 2 | 1 |
+| Image | 10 | 2 | 2 |
+| Age | 5 | 0 | 1 |
+| Key | 8 | 1 | 4 |
+
+Total flex weight stays 13, but Name now claims 4/13 of the growth budget (was 2/13) and IPv6 claims 1/13 (was 4/13).
+
+### 2. IPv6 suffix truncation in [serverlist.go:598](src/internal/ui/serverlist/serverlist.go:598)
+
+Replace the single prefix-truncation branch with a key-aware variant:
+
+```go
+if len(val) > w && w > 1 {
+    if col.Key == "ipv6" {
+        val = "…" + val[len(val)-(w-1):]
+    } else {
+        val = val[:w-1] + "…"
+    }
+}
+```
+
+Byte-indexing is safe: IPv6 addresses are ASCII-only.
+
+## Behavior examples
+
+### Narrow terminal (100 cols)
+
+- Name: guaranteed 20 cols (was ~10).
+- Status: 16 cols, common case fits exactly; SHELVED_OFFLOADED clipped.
+- IPv6: likely hidden (priority 5) — unchanged from today.
+
+### Medium terminal (180 cols)
+
+- Name: ~42 cols (was ~28).
+- Status: ~19 cols (was 20 fixed).
+- IPv6: ~20 cols (was ~45).
+- Gap between IPv6 and Floating IP reduced.
+
+### Wide terminal (300 cols)
+
+- All columns visible with less slack around IPv6. Name and Flavor/Image get the slack instead.
+
+## Testing
+
+Extend [columns_test.go](src/internal/ui/serverlist/columns_test.go):
+
+1. `TestComputeWidths_NameMinWidth` — verify Name width ≥ 20 at a width where Name is visible.
+2. `TestComputeWidths_IPv6NoLongerDominates` — at width 180, Name width > IPv6 width.
+
+Add to [serverlist_test.go](src/internal/ui/serverlist/serverlist_test.go):
+
+3. `TestRenderServerRow_IPv6SuffixTruncation` — long IPv6 truncates with leading ellipsis, preserving the suffix.
+4. `TestRenderServerRow_OtherColumnsPrefixTruncation` — ensure other columns still use prefix truncation.
+
+## Risks
+
+- Users with very narrow terminals (< ~60 cols) may see fewer columns than before because Name now reserves 20 cols instead of 10. Mitigation: lower-priority columns hide first (unchanged priority order), so the user still sees Name + Status.
+- IPv6 suffix truncation changes what users see at a glance. Minor UX shift; intentional per design.

--- a/src/internal/ui/serverlist/columns.go
+++ b/src/internal/ui/serverlist/columns.go
@@ -19,10 +19,10 @@ type Column struct {
 // DefaultColumns returns the standard server list columns, ordered by display position.
 func DefaultColumns() []Column {
 	return []Column{
-		{Title: "Name", MinWidth: 10, Flex: 2, Priority: 0, Key: "name"},
-		{Title: "Status", MinWidth: 20, Flex: 0, Priority: 0, Key: "status"},
+		{Title: "Name", MinWidth: 20, Flex: 4, Priority: 0, Key: "name"},
+		{Title: "Status", MinWidth: 16, Flex: 1, Priority: 0, Key: "status"},
 		{Title: "IPv4", MinWidth: 12, Flex: 1, Priority: 1, Key: "ipv4"},
-		{Title: "IPv6", MinWidth: 20, Flex: 4, Priority: 5, Key: "ipv6"},
+		{Title: "IPv6", MinWidth: 15, Flex: 1, Priority: 5, Key: "ipv6"},
 		{Title: "Floating IP", MinWidth: 12, Flex: 1, Priority: 3, Key: "floating"},
 		{Title: "Flavor", MinWidth: 10, Flex: 2, Priority: 1, Key: "flavor"},
 		{Title: "Image", MinWidth: 10, Flex: 2, Priority: 2, Key: "image"},
@@ -33,7 +33,13 @@ func DefaultColumns() []Column {
 
 // ComputeWidths distributes available width across visible columns,
 // hiding low-priority columns when there isn't enough space.
-func ComputeWidths(columns []Column, totalWidth int) []Column {
+//
+// maxContent optionally caps each column's growth to the longest actual value
+// in the current data (keyed by Column.Key). When a column would otherwise
+// grow past its content max, it stops at the cap and the leftover space
+// redistributes to other flex columns. Pass nil (or an empty map) to disable
+// capping and fall back to pure flex distribution.
+func ComputeWidths(columns []Column, totalWidth int, maxContent map[string]int) []Column {
 	// Reset visibility
 	for i := range columns {
 		columns[i].hidden = false
@@ -61,17 +67,15 @@ func ComputeWidths(columns []Column, totalWidth int) []Column {
 		}
 	}
 
-	// Now distribute space among visible columns
+	// Compute visible column stats.
 	gaps := -1 // spaces between columns
 	totalMin := 0
-	totalFlex := 0
 	for _, c := range columns {
 		if c.hidden {
 			continue
 		}
 		gaps++
 		totalMin += c.MinWidth
-		totalFlex += c.Flex
 	}
 	if gaps < 0 {
 		gaps = 0
@@ -83,14 +87,75 @@ func ComputeWidths(columns []Column, totalWidth int) []Column {
 	}
 
 	remaining := available - totalMin
-	if remaining > 0 && totalFlex > 0 {
-		for i := range columns {
-			if columns[i].hidden || columns[i].Flex == 0 {
+	if remaining <= 0 {
+		return columns
+	}
+
+	// Content-aware growth cap per column. -1 means no cap (unbounded).
+	cap := func(col Column) int {
+		if maxContent == nil {
+			return -1
+		}
+		v, ok := maxContent[col.Key]
+		if !ok || v <= 0 {
+			return -1
+		}
+		if v < col.MinWidth {
+			return col.MinWidth
+		}
+		return v
+	}
+
+	// Iteratively distribute remaining space by flex. Columns that would
+	// exceed their content cap lock to the cap; their excess goes back into
+	// the pool for other columns.
+	locked := make([]bool, len(columns))
+	for {
+		totalFlex := 0
+		for i, c := range columns {
+			if c.hidden || c.Flex == 0 || locked[i] {
 				continue
 			}
-			extra := remaining * columns[i].Flex / totalFlex
-			columns[i].width += extra
+			totalFlex += c.Flex
 		}
+		if totalFlex == 0 || remaining <= 0 {
+			break
+		}
+
+		newlyLocked := false
+		for i, c := range columns {
+			if c.hidden || c.Flex == 0 || locked[i] {
+				continue
+			}
+			share := remaining * c.Flex / totalFlex
+			ceiling := cap(c)
+			maxGrow := -1
+			if ceiling >= 0 {
+				maxGrow = ceiling - columns[i].width
+				if maxGrow < 0 {
+					maxGrow = 0
+				}
+			}
+			if maxGrow >= 0 && share >= maxGrow {
+				columns[i].width += maxGrow
+				remaining -= maxGrow
+				locked[i] = true
+				newlyLocked = true
+			}
+		}
+
+		if newlyLocked {
+			continue
+		}
+
+		// No more caps hit: distribute the rest by flex to uncapped columns.
+		for i, c := range columns {
+			if c.hidden || c.Flex == 0 || locked[i] {
+				continue
+			}
+			columns[i].width += remaining * c.Flex / totalFlex
+		}
+		break
 	}
 
 	return columns

--- a/src/internal/ui/serverlist/columns_test.go
+++ b/src/internal/ui/serverlist/columns_test.go
@@ -9,7 +9,7 @@ func TestComputeWidths_AllFit(t *testing.T) {
 		{Title: "A", MinWidth: 10, Flex: 1, Priority: 0},
 		{Title: "B", MinWidth: 10, Flex: 1, Priority: 0},
 	}
-	cols = ComputeWidths(cols, 100)
+	cols = ComputeWidths(cols, 100, nil)
 
 	for _, c := range cols {
 		if c.Hidden() {
@@ -29,7 +29,7 @@ func TestComputeWidths_HidesLowPriority(t *testing.T) {
 	}
 	// Total min = 60 + gaps(2) + padding(2) = 64, fits in 80
 	// But at width 50: 60 + 4 = 64 > 50, must hide
-	cols = ComputeWidths(cols, 50)
+	cols = ComputeWidths(cols, 50, nil)
 
 	if cols[0].Hidden() {
 		t.Error("priority 0 column should not be hidden")
@@ -47,7 +47,7 @@ func TestComputeWidths_FlexDistribution(t *testing.T) {
 		{Title: "A", MinWidth: 10, Flex: 1, Priority: 0},
 		{Title: "B", MinWidth: 10, Flex: 3, Priority: 0},
 	}
-	cols = ComputeWidths(cols, 60)
+	cols = ComputeWidths(cols, 60, nil)
 
 	// Available = 60 - 2(padding) - 1(gap) = 57
 	// Min total = 20, remaining = 37
@@ -63,7 +63,7 @@ func TestComputeWidths_FixedColumns(t *testing.T) {
 		{Title: "A", MinWidth: 15, Flex: 0, Priority: 0},
 		{Title: "B", MinWidth: 10, Flex: 2, Priority: 0},
 	}
-	cols = ComputeWidths(cols, 80)
+	cols = ComputeWidths(cols, 80, nil)
 
 	if cols[0].Width() != 15 {
 		t.Errorf("fixed column should stay at MinWidth 15, got %d", cols[0].Width())
@@ -73,9 +73,92 @@ func TestComputeWidths_FixedColumns(t *testing.T) {
 	}
 }
 
+func TestComputeWidths_NameReservesMinWidth(t *testing.T) {
+	cols := DefaultColumns()
+	cols = ComputeWidths(cols, 120, nil)
+
+	for _, c := range cols {
+		if c.Key == "name" {
+			if c.Hidden() {
+				t.Fatal("name column should not be hidden at width 120")
+			}
+			if c.Width() < 20 {
+				t.Errorf("name column width = %d, want >= 20", c.Width())
+			}
+			return
+		}
+	}
+	t.Fatal("name column not found")
+}
+
+func TestComputeWidths_NameGrowsFasterThanIPv6(t *testing.T) {
+	cols := DefaultColumns()
+	cols = ComputeWidths(cols, 180, nil)
+
+	var nameW, ipv6W int
+	for _, c := range cols {
+		if c.Hidden() {
+			continue
+		}
+		switch c.Key {
+		case "name":
+			nameW = c.Width()
+		case "ipv6":
+			ipv6W = c.Width()
+		}
+	}
+	if ipv6W == 0 {
+		t.Skip("ipv6 hidden at this width")
+	}
+	if nameW <= ipv6W {
+		t.Errorf("name width (%d) should exceed ipv6 width (%d) at width 180", nameW, ipv6W)
+	}
+}
+
+func TestComputeWidths_ContentCapLimitsGrowth(t *testing.T) {
+	cols := []Column{
+		{Title: "A", MinWidth: 10, Flex: 1, Priority: 0, Key: "a"},
+		{Title: "B", MinWidth: 10, Flex: 1, Priority: 0, Key: "b"},
+	}
+	// Plenty of space (200) for both. A's content caps at 15; B uncapped.
+	cols = ComputeWidths(cols, 200, map[string]int{"a": 15})
+
+	if cols[0].Width() != 15 {
+		t.Errorf("capped column width = %d, want 15", cols[0].Width())
+	}
+	// B should absorb the space A didn't take.
+	if cols[1].Width() <= 15 {
+		t.Errorf("uncapped column width = %d, want > 15 (should absorb leftover)", cols[1].Width())
+	}
+}
+
+func TestComputeWidths_ContentCapBelowMinWidth(t *testing.T) {
+	cols := []Column{
+		{Title: "A", MinWidth: 20, Flex: 1, Priority: 0, Key: "a"},
+	}
+	// Content is tiny; MinWidth still guarantees 20.
+	cols = ComputeWidths(cols, 100, map[string]int{"a": 3})
+
+	if cols[0].Width() < 20 {
+		t.Errorf("column width = %d, must respect MinWidth 20 even with small content", cols[0].Width())
+	}
+}
+
+func TestComputeWidths_UncappedWhenContentMissing(t *testing.T) {
+	cols := []Column{
+		{Title: "A", MinWidth: 10, Flex: 1, Priority: 0, Key: "a"},
+	}
+	// Empty content map: no caps, falls back to pure flex distribution.
+	cols = ComputeWidths(cols, 100, map[string]int{})
+
+	if cols[0].Width() <= 10 {
+		t.Errorf("with empty maxContent, flex should still grow column, got %d", cols[0].Width())
+	}
+}
+
 func TestComputeWidths_NarrowTerminal(t *testing.T) {
 	cols := DefaultColumns()
-	cols = ComputeWidths(cols, 40)
+	cols = ComputeWidths(cols, 40, nil)
 
 	visibleCount := 0
 	for _, c := range cols {

--- a/src/internal/ui/serverlist/serverlist.go
+++ b/src/internal/ui/serverlist/serverlist.go
@@ -171,7 +171,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		m.columns = ComputeWidths(m.columns, m.width)
+		m.recomputeColumns()
 		return m, nil
 
 	case sortClearMsg:
@@ -351,6 +351,28 @@ func (m *Model) applyFilter() {
 		m.cursor = max(0, len(m.filtered)-1)
 	}
 	m.scrollOff = 0
+	m.recomputeColumns()
+}
+
+// maxContentWidths returns the longest rendered value (in bytes, matching
+// the truncation logic in renderServerRow) for each column key across the
+// current filtered set. Keys with no data are omitted, which leaves those
+// columns uncapped in ComputeWidths.
+func (m Model) maxContentWidths() map[string]int {
+	result := make(map[string]int, len(m.columns))
+	for _, s := range m.filtered {
+		values := serverValues(s)
+		for k, v := range values {
+			if n := len(v); n > result[k] {
+				result[k] = n
+			}
+		}
+	}
+	return result
+}
+
+func (m *Model) recomputeColumns() {
+	m.columns = ComputeWidths(m.columns, m.width, m.maxContentWidths())
 }
 
 func (m Model) visibleColCount() int {
@@ -546,25 +568,17 @@ func (m Model) renderRow(render func(Column) string) string {
 	return "  " + strings.Join(parts, " ")
 }
 
-func (m Model) renderServerRow(s compute.Server, cursor bool) string {
-	// Build combined status: "ACTIVE/RUNNING"
-	statusVal := shared.StatusIcon(s.Status) + s.Status + "/" + s.PowerState
-
-	// Selection and lock indicators on name
+// serverValues returns the rendered string for each column key for the given
+// server. Shared by row rendering and content-width measurement so the two
+// stay in sync.
+func serverValues(s compute.Server) map[string]string {
 	nameVal := s.Name
 	if s.Locked {
 		nameVal = "🔒 " + nameVal
 	}
-
-	// Row prefix: selection marker
-	prefix := "  "
-	if m.selected[s.ID] {
-		prefix = "● "
-	}
-
-	values := map[string]string{
+	return map[string]string{
 		"name":     nameVal,
-		"status":   statusVal,
+		"status":   shared.StatusIcon(s.Status) + s.Status + "/" + s.PowerState,
 		"ipv4":     strings.Join(s.IPv4, ", "),
 		"ipv6":     strings.Join(s.IPv6, ", "),
 		"floating": strings.Join(s.FloatingIP, ", "),
@@ -573,6 +587,16 @@ func (m Model) renderServerRow(s compute.Server, cursor bool) string {
 		"age":      formatAge(s.Created),
 		"key":      s.KeyName,
 		"id":       s.ID,
+	}
+}
+
+func (m Model) renderServerRow(s compute.Server, cursor bool) string {
+	values := serverValues(s)
+
+	// Row prefix: selection marker
+	prefix := "  "
+	if m.selected[s.ID] {
+		prefix = "● "
 	}
 
 	isSelected := m.selected[s.ID]
@@ -596,7 +620,11 @@ func (m Model) renderServerRow(s compute.Server, cursor bool) string {
 		val := values[col.Key]
 		w := col.Width()
 		if len(val) > w && w > 1 {
-			val = val[:w-1] + "…"
+			if col.Key == "ipv6" {
+				val = "…" + val[len(val)-(w-1):]
+			} else {
+				val = val[:w-1] + "…"
+			}
 		}
 
 		style := lipgloss.NewStyle().Width(w)
@@ -792,5 +820,5 @@ func (m *Model) SetClient(client *gophercloud.ServiceClient) {
 func (m *Model) SetSize(w, h int) {
 	m.width = w
 	m.height = h
-	m.columns = ComputeWidths(m.columns, w)
+	m.recomputeColumns()
 }

--- a/src/internal/ui/serverlist/serverlist_test.go
+++ b/src/internal/ui/serverlist/serverlist_test.go
@@ -1,6 +1,7 @@
 package serverlist
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -39,5 +40,50 @@ func TestEscClearsFilterAndExitsFiltering(t *testing.T) {
 	}
 	if len(m.filtered) != len(m.servers) {
 		t.Fatalf("filtered len = %d, want %d after clear", len(m.filtered), len(m.servers))
+	}
+}
+
+func TestRenderServerRow_IPv6SuffixTruncation(t *testing.T) {
+	m := New(nil, nil, 5*time.Second)
+	m.columns = []Column{
+		{Title: "IPv6", MinWidth: 15, Flex: 0, Priority: 0, Key: "ipv6"},
+	}
+	m.columns = ComputeWidths(m.columns, 40, nil)
+
+	longIPv6 := "2001:db8:85a3:0000:0000:8a2e:0370:7334"
+	s := compute.Server{ID: "s-1", Name: "n", IPv6: []string{longIPv6}}
+
+	row := m.renderServerRow(s, false)
+
+	if !strings.Contains(row, "…") {
+		t.Errorf("expected ellipsis in row, got %q", row)
+	}
+	suffix := longIPv6[len(longIPv6)-5:]
+	if !strings.Contains(row, suffix) {
+		t.Errorf("expected suffix %q preserved in row, got %q", suffix, row)
+	}
+	prefix := longIPv6[:5]
+	if strings.Contains(row, prefix) {
+		t.Errorf("expected prefix %q to be truncated out, but found it in %q", prefix, row)
+	}
+}
+
+func TestRenderServerRow_OtherColumnsPrefixTruncation(t *testing.T) {
+	m := New(nil, nil, 5*time.Second)
+	m.columns = []Column{
+		{Title: "Name", MinWidth: 10, Flex: 0, Priority: 0, Key: "name"},
+	}
+	m.columns = ComputeWidths(m.columns, 30, nil)
+
+	longName := "very-long-server-name-here"
+	s := compute.Server{ID: "s-1", Name: longName}
+
+	row := m.renderServerRow(s, false)
+
+	if !strings.Contains(row, "…") {
+		t.Errorf("expected ellipsis in row, got %q", row)
+	}
+	if !strings.Contains(row, longName[:5]) {
+		t.Errorf("expected prefix preserved for non-ipv6 column, got %q", row)
 	}
 }


### PR DESCRIPTION
## Summary

Rework server list column sizing so columns cap at the longest actual value in the current data instead of growing into dead space. Addresses two user complaints:

1. Requiring ~300 cols of terminal width to see all columns without truncation, with a large gap between IPv6 and Floating IP even when the IPv6 values are short.
2. `Name` — the primary identifier — getting squeezed to 10 chars on narrower terminals while IPv6 hogged the flex budget.

## What changed

**Retuned column defaults in [`DefaultColumns`](src/internal/ui/serverlist/columns.go):**

| Column | MinWidth | Flex | Why |
|---|---|---|---|
| Name | 10 → **20** | 2 → **4** | guarantees 20 chars, grows fastest |
| Status | 20 → **16** | 0 → **1** | fits `■ ACTIVE/RUNNING` exactly; grows toward `■ SHELVED_OFFLOADED/SUSPENDED` (29 cols) when room allows |
| IPv6 | 20 → **15** | 4 → **1** | no longer consumes 31% of growth budget |

**Content-aware capping in [`ComputeWidths`](src/internal/ui/serverlist/columns.go):**

`ComputeWidths` now takes `maxContent map[string]int`. Flex distribution is iterative — when a column's growth would exceed its content cap, it locks at the cap and the leftover redistributes to uncapped flex columns. Passing `nil` or an empty map preserves the old pure-flex behavior.

**IPv6 suffix truncation in [`renderServerRow`](src/internal/ui/serverlist/serverlist.go):** when an IPv6 value overflows its column, truncate as `…suffix` instead of `prefix…`. The host portion (differs per server) stays visible; the shared network prefix is what gets cut.

**Shared content source:** factored `serverValues(s)` so row rendering and width measurement produce the exact same strings. Prevents drift.

**Wiring:** added `maxContentWidths()` and `recomputeColumns()` on `Model`; hooked into `applyFilter`, `WindowSizeMsg`, and `SetSize`.

## Behavior

- Short server names no longer create whitespace between Name and Status.
- Full IPv6 addresses render untruncated when the terminal has room for them.
- Status stays compact at 16 cols when only `ACTIVE/RUNNING` is present; grows only when a longer status appears.
- Narrow terminals still guarantee Name ≥ 20 cols; lower-priority columns hide as before.
- Minor data-driven jitter: a new SHELVED_OFFLOADED server causes Status to grow on the next refresh. Acceptable tradeoff.

## Design doc

[`docs/superpowers/specs/2026-04-17-serverlist-adaptive-columns-design.md`](docs/superpowers/specs/2026-04-17-serverlist-adaptive-columns-design.md) captures the problem, goals, and trade-offs.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] New tests cover: content cap limits growth, cap respects MinWidth, empty map = uncapped, Name reserves 20 cols, Name flex dominates IPv6, IPv6 suffix truncation, other columns still prefix-truncate
- [x] Eyeball at 80, 120, 180, 300 terminal widths with a mix of server statuses
- [x] Confirm no regression on very narrow terminal (column hiding order unchanged)