### PR TITLE
fix: address pre-release issues #141 #142 #143 #145 #146

### DIFF
--- a/src/internal/app/actions_resource.go
+++ b/src/internal/app/actions_resource.go
@@ -79,7 +79,18 @@ func (m Model) openVolumeDeleteConfirm() (Model, tea.Cmd) {
 	return m, nil
 }
 
+// blockStorageAvailable reports whether the connected cloud exposes a
+// Cinder (block storage) endpoint. Volume attach/detach/create/delete flows
+// depend on this client being non-nil; callers must gate on this before
+// invoking any volume action.
+func (m Model) blockStorageAvailable() bool {
+	return m.client.BlockStorage != nil
+}
+
 func (m Model) openVolumeAttach() (Model, tea.Cmd) {
+	if !m.blockStorageAvailable() {
+		return m, nil
+	}
 	var id, name string
 	switch m.view {
 	case viewVolumeDetail:
@@ -102,6 +113,9 @@ func (m Model) openVolumeAttach() (Model, tea.Cmd) {
 }
 
 func (m Model) openVolumeDetach() (Model, tea.Cmd) {
+	if !m.blockStorageAvailable() {
+		return m, nil
+	}
 	var id, name string
 	switch m.view {
 	case viewVolumeDetail:
@@ -130,6 +144,9 @@ func (m Model) openVolumeDetach() (Model, tea.Cmd) {
 }
 
 func (m Model) openServerVolumeAttach() (Model, tea.Cmd) {
+	if !m.blockStorageAvailable() {
+		return m, nil
+	}
 	var serverID, serverName string
 	switch m.view {
 	case viewServerDetail:
@@ -152,6 +169,9 @@ func (m Model) openServerVolumeAttach() (Model, tea.Cmd) {
 }
 
 func (m Model) openServerVolumeDetach() (Model, tea.Cmd) {
+	if !m.blockStorageAvailable() {
+		return m, nil
+	}
 	if m.view != viewServerDetail {
 		return m, nil
 	}

--- a/src/internal/app/app.go
+++ b/src/internal/app/app.go
@@ -657,6 +657,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Volume detach from server detail volumes pane
 			if m.view == viewServerDetail && m.serverDetail.FocusedOnVolumes() {
 				if key.Matches(msg, shared.Keys.Detach) {
+					if !m.blockStorageAvailable() {
+						m.statusBar.StickyHint = "Block storage unavailable in this cloud"
+						return m, nil
+					}
 					return m.openServerVolumeDetach()
 				}
 			}
@@ -720,6 +724,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m.doRevertResize()
 			}
 			if key.Matches(msg, shared.Keys.Attach) {
+				if !m.blockStorageAvailable() {
+					m.statusBar.StickyHint = "Block storage unavailable in this cloud"
+					return m, nil
+				}
 				return m.openServerVolumeAttach()
 			}
 			if key.Matches(msg, shared.Keys.AssignFIP) {

--- a/src/internal/app/app.go
+++ b/src/internal/app/app.go
@@ -863,7 +863,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					key.Matches(msg, shared.Keys.Enter) ||
 					key.Matches(msg, shared.Keys.StopStart) ||
 					msg.String() == "ctrl+h" {
-					m.statusBar.Error = "Load balancer is " + lb.ProvisioningStatus + ", please wait..."
+					m.statusBar.StickyHint = "Load balancer is " + lb.ProvisioningStatus + ", please wait..."
 					return m, nil
 				}
 			}

--- a/src/internal/app/app.go
+++ b/src/internal/app/app.go
@@ -1160,7 +1160,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.latestVersion = msg.Latest
 		m.downloadURL = msg.DownloadURL
 		m.checksumsURL = msg.ChecksumsURL
-		m.statusBar.Hint = fmt.Sprintf("Upgrade available: %s", msg.Latest)
+		if msg.ChecksumsURL == "" {
+			m.statusBar.StickyHint = fmt.Sprintf("update %s skipped: checksums unavailable", msg.Latest)
+		} else {
+			m.statusBar.Hint = fmt.Sprintf("Upgrade available: %s", msg.Latest)
+		}
 		return m, nil
 
 	case shared.ConfigChangedMsg:

--- a/src/internal/app/app_keyrouting_test.go
+++ b/src/internal/app/app_keyrouting_test.go
@@ -5,15 +5,16 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/gophercloud/gophercloud/v2"
 	"github.com/larkly/lazystack/internal/cloud"
 	"github.com/larkly/lazystack/internal/compute"
-	"github.com/larkly/lazystack/internal/ui/serverlist"
 	"github.com/larkly/lazystack/internal/ui/serverdetail"
+	"github.com/larkly/lazystack/internal/ui/serverlist"
 )
 
 func TestServerDetailCtrlAOpensVolumePicker(t *testing.T) {
 	m := newTestModel("dev", false)
-	m.client = &cloud.Client{}
+	m.client = &cloud.Client{BlockStorage: &gophercloud.ServiceClient{}}
 	m.view = viewServerDetail
 	m.serverDetail = testServerDetailWithServer("srv-1", "srv-1")
 
@@ -21,6 +22,22 @@ func TestServerDetailCtrlAOpensVolumePicker(t *testing.T) {
 	updated := res.(Model)
 	if !updated.volumePicker.Active {
 		t.Fatalf("volume picker should be active after ctrl+a on server detail")
+	}
+}
+
+func TestServerDetailCtrlAWithoutBlockStorageIsGated(t *testing.T) {
+	m := newTestModel("dev", false)
+	m.client = &cloud.Client{}
+	m.view = viewServerDetail
+	m.serverDetail = testServerDetailWithServer("srv-1", "srv-1")
+
+	res, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: 'a', Mod: tea.ModCtrl}))
+	updated := res.(Model)
+	if updated.volumePicker.Active {
+		t.Fatalf("volume picker should not open when block storage is unavailable")
+	}
+	if updated.statusBar.StickyHint == "" {
+		t.Fatalf("expected a sticky hint explaining block storage is unavailable")
 	}
 }
 

--- a/src/internal/network/networks.go
+++ b/src/internal/network/networks.go
@@ -3,6 +3,7 @@ package network
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/subnetpools"
@@ -326,27 +327,47 @@ func UpdateSubnet(ctx context.Context, client *gophercloud.ServiceClient, id str
 	return nil
 }
 
-// ListExternalNetworks fetches networks where router:external is true.
+// externalListOpts wraps networks.ListOpts to add the router:external=true
+// filter that the standard ListOpts does not expose directly.
+type externalListOpts struct {
+	networks.ListOpts
+}
+
+func (o externalListOpts) ToNetworkListQuery() (string, error) {
+	q, err := o.ListOpts.ToNetworkListQuery()
+	if err != nil {
+		return "", err
+	}
+	if strings.Contains(q, "?") {
+		return q + "&router:external=true", nil
+	}
+	return q + "?router:external=true", nil
+}
+
+// ListExternalNetworks fetches networks where router:external is true,
+// following pagination so large deployments are not silently truncated.
 func ListExternalNetworks(ctx context.Context, client *gophercloud.ServiceClient) ([]Network, error) {
 	shared.Debugf("[network] listing external networks")
-	url := client.ServiceURL("networks") + "?router:external=true"
-	var body struct {
-		Networks []struct {
-			ID     string `json:"id"`
-			Name   string `json:"name"`
-			Status string `json:"status"`
-		} `json:"networks"`
-	}
-	resp, err := client.Get(ctx, url, &body, nil)
+	var result []Network
+	err := networks.List(client, externalListOpts{}).EachPage(ctx, func(_ context.Context, page pagination.Page) (bool, error) {
+		extracted, err := networks.ExtractNetworks(page)
+		if err != nil {
+			return false, err
+		}
+		for _, n := range extracted {
+			result = append(result, Network{
+				ID:        n.ID,
+				Name:      n.Name,
+				Status:    n.Status,
+				Shared:    n.Shared,
+				SubnetIDs: n.Subnets,
+			})
+		}
+		return true, nil
+	})
 	if err != nil {
 		shared.Debugf("[network] list external networks: %v", err)
 		return nil, fmt.Errorf("listing external networks: %w", err)
-	}
-	resp.Body.Close()
-
-	result := make([]Network, len(body.Networks))
-	for i, n := range body.Networks {
-		result[i] = Network{ID: n.ID, Name: n.Name, Status: n.Status}
 	}
 	shared.Debugf("[network] listed %d external networks", len(result))
 	return result, nil

--- a/src/internal/selfupdate/selfupdate.go
+++ b/src/internal/selfupdate/selfupdate.go
@@ -145,14 +145,16 @@ func Apply(ctx context.Context, downloadURL, checksumsURL string) error {
 
 	got := hex.EncodeToString(hasher.Sum(nil))
 
-	if checksumsURL != "" {
-		shared.Debugf("[selfupdate] Apply: verifying checksum")
-		if err := verifyChecksum(ctx, checksumsURL, got); err != nil {
-			shared.Debugf("[selfupdate] Apply: error checksum verification: %v", err)
-			return err
-		}
-		shared.Debugf("[selfupdate] Apply: checksum verified")
+	if checksumsURL == "" {
+		shared.Debugf("[selfupdate] Apply: refusing to install without checksums")
+		return fmt.Errorf("refusing to apply update: release has no SHA256SUMS asset")
 	}
+	shared.Debugf("[selfupdate] Apply: verifying checksum")
+	if err := verifyChecksum(ctx, checksumsURL, got); err != nil {
+		shared.Debugf("[selfupdate] Apply: error checksum verification: %v", err)
+		return err
+	}
+	shared.Debugf("[selfupdate] Apply: checksum verified")
 
 	if err := os.Chmod(tmpPath, 0755); err != nil {
 		shared.Debugf("[selfupdate] Apply: error setting permissions: %v", err)

--- a/src/internal/ui/consoleurl/consoleurl.go
+++ b/src/internal/ui/consoleurl/consoleurl.go
@@ -71,7 +71,7 @@ func (m Model) openInBrowser() (Model, tea.Cmd) {
 	case "darwin":
 		cmd = exec.Command("open", url)
 	case "windows":
-		cmd = exec.Command("cmd", "/c", "start", url)
+		cmd = exec.Command("cmd", "/c", "start", "", url)
 	default:
 		cmd = exec.Command("xdg-open", url)
 	}

--- a/src/internal/ui/serverdetail/serverdetail.go
+++ b/src/internal/ui/serverdetail/serverdetail.go
@@ -1466,6 +1466,9 @@ func (m Model) Hints() string {
 	case focusInterfaces:
 		return "\u2191\u2193 scroll interfaces \u2022 " + base
 	case focusVolumes:
+		if m.blockClient == nil {
+			return "\u2191\u2193 select \u2022 enter detail \u2022 ^b assign FIP \u2022 " + base
+		}
 		return "\u2191\u2193 select \u2022 enter detail \u2022 ^a attach volume \u2022 ^t detach \u2022 ^b assign FIP \u2022 " + base
 	case focusConsole:
 		return "\u2191\u2193 scroll log \u2022 g top \u2022 G bottom \u2022 " + base


### PR DESCRIPTION
## Summary

Five pre-release punch-list issues from the code review, one commit per fix so any single change can be reverted cleanly.

Closes #141
Closes #142
Closes #143
Closes #145
Closes #146

| Commit | Issue | Change |
| --- | --- | --- |
| `fix(consoleurl)` | #143 | Pass empty title to Windows `cmd /c start` so URLs with `&` and spaces are preserved |
| `fix(lb)` | #146 | Use `StickyHint` instead of persistent `Error` for the LB PENDING_* block so it clears on next keypress |
| `fix(selfupdate)` | #142 | Hard-fail `Apply` when a release has no `SHA256SUMS`; surface a skipped-update hint when the updater detects a new version without checksums |
| `fix(network)` | #145 | Paginate external-network discovery via `networks.List().EachPage()` with a `router:external=true` `ListOptsBuilder` wrapper |
| `fix(volume)` | #141 | Gate volume attach/detach on `m.client.BlockStorage != nil`: keybind-site sticky hint, defense-in-depth guards in four action functions, omit `^a/^t` from volume pane hints when unavailable |
| `test(app)` | follow-up to #141 | Update existing Ctrl+A test to the new contract; add gated-path test asserting no picker + sticky hint |

Issue #144 (multiattach volume state) is deferred — it needs schema changes and UI design beyond this fix-batch.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` all packages passing
- [ ] Manual on a real cloud: attach/detach flows still work on Cinder-enabled clouds; Windows console URL with \`&\` opens correctly; LB pending warning clears after provisioning; external networks list on a multi-page Neutron deployment