### PR TITLE
fix: use explicit 0600 perms for image downloads

### DIFF
--- a/src/internal/ui/imagedownload/imagedownload.go
+++ b/src/internal/ui/imagedownload/imagedownload.go
@@ -409,7 +409,11 @@ func (m Model) submit() (Model, tea.Cmd) {
 			sharedTotal.Store(contentLength)
 		}
 
-		f, err := os.Create(path)
+		// Use 0600 to match the rest of the codebase (debug log, selfupdate
+		// cache, keypair private keys). Downloaded images can contain golden
+		// images or cloud-init userdata that users may reasonably expect to
+		// stay private to their account; os.Create would leave them 0644.
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 		if err != nil {
 			return downloadErrMsg{err: fmt.Errorf("creating file: %w", err)}
 		}


### PR DESCRIPTION
Closes #157.

## Summary

`os.Create(path)` in `imagedownload.go` creates files with mode `0666` before umask, leaving downloaded OpenStack images world-readable (`0644`) on typical systems. This is inconsistent with every other file-write path in the TUI, which uses `0600`:

| Call site | Mode |
| --- | --- |
| `internal/shared/debug.go:29` (debug log) | `0o600` |
| `internal/selfupdate/cache.go:81` (update cache) | `0o600` |
| `internal/ui/keypaircreate/keypaircreate.go:234` (private key) | `0600` |
| `internal/ui/imagedownload/imagedownload.go:412` (image file) | ~~`0666&~umask`~~ → `0o600` |

Downloaded images can contain golden images or cloud-init userdata a user may reasonably expect to stay private, so match the convention.

## Change

One line, one file — swap `os.Create` for `os.OpenFile(..., os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)`. The form mirrors `internal/shared/debug.go:29` exactly.

## Test plan

- [x] `go build ./internal/ui/imagedownload/` passes
- No unit tests exist for this download path today; the permission change is observable only at runtime against a live Glance endpoint.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DuUhbWnCrZRMDft6upqA1T)_