### PR TITLE
fix(imagedownload): use explicit 0600 perms for downloaded image files

### DIFF
--- a/src/internal/ui/imagedownload/imagedownload.go
+++ b/src/internal/ui/imagedownload/imagedownload.go
@@ -409,7 +409,7 @@ func (m Model) submit() (Model, tea.Cmd) {
 			sharedTotal.Store(contentLength)
 		}
 
-		f, err := os.Create(path)
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 		if err != nil {
 			return downloadErrMsg{err: fmt.Errorf("creating file: %w", err)}
 		}


### PR DESCRIPTION
## Summary

Fixes #157.

`os.Create` opens the destination file with mode `0666` before umask, which on typical systems leaves the downloaded image world-readable (`0644`). Switch to `os.OpenFile` with an explicit `0600` mode so the downloaded file is created with the same conservative permissions used elsewhere in the codebase (private keys, debug log, selfupdate cache).

Downloaded OpenStack images can include golden images, cloud-init userdata bakes, or other artifacts a user may reasonably expect to remain private to their account.

## Change

`src/internal/ui/imagedownload/imagedownload.go:412`

```diff
-f, err := os.Create(path)
+f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
```

## Test plan

- [x] `go build ./...` from `src/` — passes
- [x] `go vet ./...` — passes
- [ ] Manual: download an image via the TUI, confirm `ls -l` shows `-rw-------` on the resulting file
