### PR TITLE
fix(imagedownload): use 0600 perms instead of os.Create default umask

### DIFF
--- a/src/internal/ui/imagedownload/imagedownload.go
+++ b/src/internal/ui/imagedownload/imagedownload.go
@@ -409,7 +409,7 @@ func (m Model) submit() (Model, tea.Cmd) {
 			sharedTotal.Store(contentLength)
 		}
 
-		f, err := os.Create(path)
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 		if err != nil {
 			return downloadErrMsg{err: fmt.Errorf("creating file: %w", err)}
 		}


### PR DESCRIPTION
## Summary

Closes #157.

`src/internal/ui/imagedownload/imagedownload.go:412` used `os.Create(path)` to open the destination file for an image download. `os.Create` creates files with mode `0666` before umask, which on typical systems leaves the downloaded file world-readable (`0644`).

This is inconsistent with how the rest of the codebase handles files produced by the TUI (private keys, debug log, selfupdate cache all use `0600`). Downloaded OpenStack images can include golden images, cloud-init userdata bakes, or other artifacts a user may reasonably expect to remain private to their account.

## Change

```go
// before
f, err := os.Create(path)

// after
f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
```

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./...` — all existing tests still pass; no test files for this package
- [ ] Manual verification: download an image and check `ls -l` shows `-rw-------` instead of `-rw-r--r--`

---
_Generated by [Claude Code](https://claude.ai/code/session_013YjhsZEG5GcuBT82ikjiMJ)_