### PR TITLE
refactor(app): consolidate modal dispatch, add NavStack for back-navigation

### DIFF
--- a/src/internal/app/actions_server.go
+++ b/src/internal/app/actions_server.go
@@ -348,7 +348,7 @@ func (m Model) openConsoleLog() (Model, tea.Cmd) {
 	}
 	m.consoleLog = consolelog.New(m.client.Compute, id, name)
 	m.consoleLog.SetSize(m.width, m.height)
-	m.previousView = m.view
+	m.nav.Push(m.view, m.activeTab)
 	m.view = viewConsoleLog
 	m.statusBar.CurrentView = "consolelog"
 	m.statusBar.Hint = m.consoleLog.Hints()
@@ -371,7 +371,7 @@ func (m Model) openActionLog() (Model, tea.Cmd) {
 	}
 	m.actionLog = actionlog.New(m.client.Compute, id, name)
 	m.actionLog.SetSize(m.width, m.height)
-	m.previousView = m.view
+	m.nav.Push(m.view, m.activeTab)
 	m.view = viewActionLog
 	m.statusBar.CurrentView = "actionlog"
 	m.statusBar.Hint = m.actionLog.Hints()

--- a/src/internal/app/app.go
+++ b/src/internal/app/app.go
@@ -20,9 +20,9 @@ import (
 	"github.com/larkly/lazystack/internal/ui/cloneprogress"
 	"github.com/larkly/lazystack/internal/ui/cloudpicker"
 	"github.com/larkly/lazystack/internal/ui/configview"
-	"github.com/larkly/lazystack/internal/ui/copypicker"
 	"github.com/larkly/lazystack/internal/ui/consolelog"
 	"github.com/larkly/lazystack/internal/ui/consoleurl"
+	"github.com/larkly/lazystack/internal/ui/copypicker"
 	"github.com/larkly/lazystack/internal/ui/fippicker"
 	"github.com/larkly/lazystack/internal/ui/floatingiplist"
 	"github.com/larkly/lazystack/internal/ui/help"
@@ -34,11 +34,11 @@ import (
 	"github.com/larkly/lazystack/internal/ui/keypairdetail"
 	"github.com/larkly/lazystack/internal/ui/keypairlist"
 	"github.com/larkly/lazystack/internal/ui/lbcreate"
-	"github.com/larkly/lazystack/internal/ui/lbview"
 	"github.com/larkly/lazystack/internal/ui/lblistenercreate"
 	"github.com/larkly/lazystack/internal/ui/lbmembercreate"
 	"github.com/larkly/lazystack/internal/ui/lbmonitorcreate"
 	"github.com/larkly/lazystack/internal/ui/lbpoolcreate"
+	"github.com/larkly/lazystack/internal/ui/lbview"
 	"github.com/larkly/lazystack/internal/ui/modal"
 	"github.com/larkly/lazystack/internal/ui/networkcreate"
 	"github.com/larkly/lazystack/internal/ui/networkview"
@@ -187,6 +187,7 @@ type Model struct {
 	autoCloud           string
 	previousView        activeView
 	returnToView        activeView // for cross-resource navigation back-nav
+	nav                 NavStack   // explicit navigation stack (H2)
 	refreshInterval     time.Duration
 	minWidth            int
 	minHeight           int
@@ -309,34 +310,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 		m.tooSmall = m.width < m.minWidth || m.height < m.minHeight
 		m.cloudPicker.SetSize(m.width, m.height)
-		m.confirm.SetSize(m.width, m.height)
-		m.errModal.SetSize(m.width, m.height)
+		m.setSizeAllModals(m.width, m.height)
 		m.help.Width = m.width
 		m.help.Height = m.height
 		m.quotaView.Width = m.width
 		m.quotaView.Height = m.height
-		m.serverRename.SetSize(m.width, m.height)
-		m.serverRebuild.SetSize(m.width, m.height)
-		m.serverSnapshot.SetSize(m.width, m.height)
-		m.serverResize.SetSize(m.width, m.height)
-		m.sshPrompt.SetSize(m.width, m.height)
-		m.copyPicker.SetSize(m.width, m.height)
-		m.consoleURL.SetSize(m.width, m.height)
-		m.vmPassword.SetSize(m.width, m.height)
-		m.fipPicker.SetSize(m.width, m.height)
-		m.serverPicker.SetSize(m.width, m.height)
-		m.volumePicker.SetSize(m.width, m.height)
-		m.sgCreate.SetSize(m.width, m.height)
-		m.sgRuleCreate.SetSize(m.width, m.height)
-		m.networkCreate.SetSize(m.width, m.height)
-		m.subnetCreate.SetSize(m.width, m.height)
-		m.subnetEdit.SetSize(m.width, m.height)
-		m.portCreate.SetSize(m.width, m.height)
-		m.portEdit.SetSize(m.width, m.height)
-		m.routerCreate.SetSize(m.width, m.height)
-		m.subnetPicker.SetSize(m.width, m.height)
-		m.projectPicker.SetSize(m.width, m.height)
-		m.cloneProgress.SetSize(m.width, m.height)
 		m.configView.Width = m.width
 		m.configView.Height = m.height
 		m.statusBar.Width = m.width
@@ -380,207 +358,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateModal(msg)
 		}
 
-		// Clone progress modal intercepts all keys when active
-		if m.cloneProgress.Active {
-			var cmd tea.Cmd
-			m.cloneProgress, cmd = m.cloneProgress.Update(msg)
-			return m, cmd
-		}
-
-		// Rename modal intercepts all keys when active
-		if m.serverRename.Active {
-			var cmd tea.Cmd
-			m.serverRename, cmd = m.serverRename.Update(msg)
-			return m, cmd
-		}
-
-		// Rebuild modal intercepts all keys when active
-		if m.serverRebuild.Active {
-			var cmd tea.Cmd
-			m.serverRebuild, cmd = m.serverRebuild.Update(msg)
-			return m, cmd
-		}
-
-		// Snapshot modal intercepts all keys when active
-		if m.serverSnapshot.Active {
-			var cmd tea.Cmd
-			m.serverSnapshot, cmd = m.serverSnapshot.Update(msg)
-			return m, cmd
-		}
-
-		// Resize modal intercepts all keys when active
-		if m.serverResize.Active {
-			var cmd tea.Cmd
-			m.serverResize, cmd = m.serverResize.Update(msg)
-			return m, cmd
-		}
-
-		// SSH prompt modal intercepts all keys when active
-		if m.sshPrompt.Active {
-			var cmd tea.Cmd
-			m.sshPrompt, cmd = m.sshPrompt.Update(msg)
-			return m, cmd
-		}
-
-		// Copy picker modal intercepts all keys when active
-		if m.copyPicker.Active {
-			var cmd tea.Cmd
-			m.copyPicker, cmd = m.copyPicker.Update(msg)
-			return m, cmd
-		}
-
-		// Console URL modal intercepts all keys when active
-		if m.consoleURL.Active {
-			var cmd tea.Cmd
-			m.consoleURL, cmd = m.consoleURL.Update(msg)
-			return m, cmd
-		}
-
-		// VM password modal intercepts all keys when active
-		if m.vmPassword.Active {
-			var cmd tea.Cmd
-			m.vmPassword, cmd = m.vmPassword.Update(msg)
-			return m, cmd
-		}
-
-		// FIP picker modal intercepts all keys when active
-		if m.fipPicker.Active {
-			var cmd tea.Cmd
-			m.fipPicker, cmd = m.fipPicker.Update(msg)
-			return m, cmd
-		}
-
-		// Server picker modal intercepts all keys when active
-		if m.serverPicker.Active {
-			var cmd tea.Cmd
-			m.serverPicker, cmd = m.serverPicker.Update(msg)
-			return m, cmd
-		}
-
-		// Volume picker modal intercepts all keys when active
-		if m.volumePicker.Active {
-			var cmd tea.Cmd
-			m.volumePicker, cmd = m.volumePicker.Update(msg)
-			return m, cmd
-		}
-
-		// Router create modal intercepts all keys when active
-		if m.routerCreate.Active {
-			var cmd tea.Cmd
-			m.routerCreate, cmd = m.routerCreate.Update(msg)
-			return m, cmd
-		}
-
-		// Subnet picker modal intercepts all keys when active
-		if m.subnetPicker.Active {
-			var cmd tea.Cmd
-			m.subnetPicker, cmd = m.subnetPicker.Update(msg)
-			return m, cmd
-		}
-
-		// Network create modal intercepts all keys when active
-		if m.networkCreate.Active {
-			var cmd tea.Cmd
-			m.networkCreate, cmd = m.networkCreate.Update(msg)
-			return m, cmd
-		}
-
-		// Subnet create modal intercepts all keys when active
-		if m.subnetCreate.Active {
-			var cmd tea.Cmd
-			m.subnetCreate, cmd = m.subnetCreate.Update(msg)
-			return m, cmd
-		}
-
-		// Subnet edit modal intercepts all keys when active
-		if m.subnetEdit.Active {
-			var cmd tea.Cmd
-			m.subnetEdit, cmd = m.subnetEdit.Update(msg)
-			return m, cmd
-		}
-
-		// Port create/edit modals intercept all keys when active
-		if m.portCreate.Active {
-			var cmd tea.Cmd
-			m.portCreate, cmd = m.portCreate.Update(msg)
-			return m, cmd
-		}
-		if m.portEdit.Active {
-			var cmd tea.Cmd
-			m.portEdit, cmd = m.portEdit.Update(msg)
-			return m, cmd
-		}
-
-		// SG create modal intercepts all keys when active
-		if m.sgCreate.Active {
-			var cmd tea.Cmd
-			m.sgCreate, cmd = m.sgCreate.Update(msg)
-			return m, cmd
-		}
-
-		// SG rule create modal intercepts all keys when active
-		if m.sgRuleCreate.Active {
-			var cmd tea.Cmd
-			m.sgRuleCreate, cmd = m.sgRuleCreate.Update(msg)
-			return m, cmd
-		}
-
-		// Image modals intercept all keys when active
-		if m.imageEdit.Active {
-			var cmd tea.Cmd
-			m.imageEdit, cmd = m.imageEdit.Update(msg)
-			return m, cmd
-		}
-		if m.imageCreate.Active {
-			var cmd tea.Cmd
-			m.imageCreate, cmd = m.imageCreate.Update(msg)
-			return m, cmd
-		}
-		if m.imageDownload.Active {
-			var cmd tea.Cmd
-			m.imageDownload, cmd = m.imageDownload.Update(msg)
-			return m, cmd
-		}
-
-		// LB create/edit modal intercepts all keys when active
-		if m.lbCreate.Active {
-			var cmd tea.Cmd
-			m.lbCreate, cmd = m.lbCreate.Update(msg)
-			return m, cmd
-		}
-
-		// LB listener create modal intercepts all keys when active
-		if m.lbListenerCreate.Active {
-			var cmd tea.Cmd
-			m.lbListenerCreate, cmd = m.lbListenerCreate.Update(msg)
-			return m, cmd
-		}
-
-		// LB pool create modal intercepts all keys when active
-		if m.lbPoolCreate.Active {
-			var cmd tea.Cmd
-			m.lbPoolCreate, cmd = m.lbPoolCreate.Update(msg)
-			return m, cmd
-		}
-
-		// LB member create modal intercepts all keys when active
-		if m.lbMemberCreate.Active {
-			var cmd tea.Cmd
-			m.lbMemberCreate, cmd = m.lbMemberCreate.Update(msg)
-			return m, cmd
-		}
-
-		// LB monitor create modal intercepts all keys when active
-		if m.lbMonitorCreate.Active {
-			var cmd tea.Cmd
-			m.lbMonitorCreate, cmd = m.lbMonitorCreate.Update(msg)
-			return m, cmd
-		}
-
-		// Project picker modal intercepts all keys when active
-		if m.projectPicker.Active {
-			var cmd tea.Cmd
-			m.projectPicker, cmd = m.projectPicker.Update(msg)
+		if ok, cmd := m.updateAnyModal(msg); ok {
 			return m, cmd
 		}
 
@@ -1433,137 +1211,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.quotaView, cmd = m.quotaView.Update(msg)
 			return m, tea.Batch(viewCmd, cmd)
 		}
-		// Also route to active modals (for spinner, loaded msgs)
-		if m.serverRename.Active {
-			var cmd tea.Cmd
-			m.serverRename, cmd = m.serverRename.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.serverRebuild.Active {
-			var cmd tea.Cmd
-			m.serverRebuild, cmd = m.serverRebuild.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.serverSnapshot.Active {
-			var cmd tea.Cmd
-			m.serverSnapshot, cmd = m.serverSnapshot.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.serverResize.Active {
-			var cmd tea.Cmd
-			m.serverResize, cmd = m.serverResize.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.fipPicker.Active {
-			var cmd tea.Cmd
-			m.fipPicker, cmd = m.fipPicker.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.serverPicker.Active {
-			var cmd tea.Cmd
-			m.serverPicker, cmd = m.serverPicker.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.volumePicker.Active {
-			var cmd tea.Cmd
-			m.volumePicker, cmd = m.volumePicker.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.routerCreate.Active {
-			var cmd tea.Cmd
-			m.routerCreate, cmd = m.routerCreate.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.subnetPicker.Active {
-			var cmd tea.Cmd
-			m.subnetPicker, cmd = m.subnetPicker.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.networkCreate.Active {
-			var cmd tea.Cmd
-			m.networkCreate, cmd = m.networkCreate.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.subnetCreate.Active {
-			var cmd tea.Cmd
-			m.subnetCreate, cmd = m.subnetCreate.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.subnetEdit.Active {
-			var cmd tea.Cmd
-			m.subnetEdit, cmd = m.subnetEdit.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.portCreate.Active {
-			var cmd tea.Cmd
-			m.portCreate, cmd = m.portCreate.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.portEdit.Active {
-			var cmd tea.Cmd
-			m.portEdit, cmd = m.portEdit.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.sgCreate.Active {
-			var cmd tea.Cmd
-			m.sgCreate, cmd = m.sgCreate.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.sgRuleCreate.Active {
-			var cmd tea.Cmd
-			m.sgRuleCreate, cmd = m.sgRuleCreate.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.imageEdit.Active {
-			var cmd tea.Cmd
-			m.imageEdit, cmd = m.imageEdit.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.imageCreate.Active {
-			var cmd tea.Cmd
-			m.imageCreate, cmd = m.imageCreate.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.imageDownload.Active {
-			var cmd tea.Cmd
-			m.imageDownload, cmd = m.imageDownload.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.lbCreate.Active {
-			var cmd tea.Cmd
-			m.lbCreate, cmd = m.lbCreate.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.lbListenerCreate.Active {
-			var cmd tea.Cmd
-			m.lbListenerCreate, cmd = m.lbListenerCreate.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.lbPoolCreate.Active {
-			var cmd tea.Cmd
-			m.lbPoolCreate, cmd = m.lbPoolCreate.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.lbMemberCreate.Active {
-			var cmd tea.Cmd
-			m.lbMemberCreate, cmd = m.lbMemberCreate.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.lbMonitorCreate.Active {
-			var cmd tea.Cmd
-			m.lbMonitorCreate, cmd = m.lbMonitorCreate.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		if m.projectPicker.Active {
-			var cmd tea.Cmd
-			m.projectPicker, cmd = m.projectPicker.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
-		}
-		// Route non-key messages to clone progress when running (even if dismissed)
-		if m.cloneProgress.Running() {
-			var cmd tea.Cmd
-			m.cloneProgress, cmd = m.cloneProgress.Update(msg)
-			return m, tea.Batch(viewCmd, cmd)
+		// Route to any active modals for background messages
+		if modalCmd := m.updateAnyModalBackground(msg); modalCmd != nil {
+			return m, tea.Batch(viewCmd, modalCmd)
 		}
 		return m, viewCmd
 	}

--- a/src/internal/app/modal.go
+++ b/src/internal/app/modal.go
@@ -1,0 +1,409 @@
+package app
+
+import tea "charm.land/bubbletea/v2"
+
+// isAnyModalActive checks all overlay/modals in priority order and returns
+// true if any of them is active. This replaces the ~25 if-blocks duplicated
+// between Update() and View().
+func (m *Model) isAnyModalActive() bool {
+	return m.activeModal != modalNone ||
+		m.cloneProgress.Active ||
+		m.serverRename.Active ||
+		m.serverRebuild.Active ||
+		m.serverSnapshot.Active ||
+		m.serverResize.Active ||
+		m.sshPrompt.Active ||
+		m.copyPicker.Active ||
+		m.consoleURL.Active ||
+		m.vmPassword.Active ||
+		m.fipPicker.Active ||
+		m.serverPicker.Active ||
+		m.volumePicker.Active ||
+		m.routerCreate.Active ||
+		m.subnetPicker.Active ||
+		m.networkCreate.Active ||
+		m.subnetCreate.Active ||
+		m.subnetEdit.Active ||
+		m.portCreate.Active ||
+		m.portEdit.Active ||
+		m.sgCreate.Active ||
+		m.sgRuleCreate.Active ||
+		m.imageEdit.Active ||
+		m.imageCreate.Active ||
+		m.imageDownload.Active ||
+		m.lbCreate.Active ||
+		m.lbListenerCreate.Active ||
+		m.lbPoolCreate.Active ||
+		m.lbMemberCreate.Active ||
+		m.lbMonitorCreate.Active ||
+		m.projectPicker.Active
+}
+
+// activeModalView returns the view string of whichever modal/overlay is active.
+// Returns ("", false) if no modal is active.
+func (m *Model) activeModalView() (string, bool) {
+	if m.activeModal == modalConfirm {
+		return m.confirm.View(), true
+	}
+	if m.activeModal == modalError {
+		return m.errModal.View(), true
+	}
+	if m.cloneProgress.Active {
+		return m.cloneProgress.View(), true
+	}
+	if m.serverRename.Active {
+		return m.serverRename.View(), true
+	}
+	if m.serverRebuild.Active {
+		return m.serverRebuild.View(), true
+	}
+	if m.serverSnapshot.Active {
+		return m.serverSnapshot.View(), true
+	}
+	if m.serverResize.Active {
+		return m.serverResize.View(), true
+	}
+	if m.sshPrompt.Active {
+		return m.sshPrompt.View(), true
+	}
+	if m.copyPicker.Active {
+		return m.copyPicker.View(), true
+	}
+	if m.consoleURL.Active {
+		return m.consoleURL.View(), true
+	}
+	if m.vmPassword.Active {
+		return m.vmPassword.View(), true
+	}
+	if m.fipPicker.Active {
+		return m.fipPicker.View(), true
+	}
+	if m.serverPicker.Active {
+		return m.serverPicker.View(), true
+	}
+	if m.volumePicker.Active {
+		return m.volumePicker.View(), true
+	}
+	if m.routerCreate.Active {
+		return m.routerCreate.View(), true
+	}
+	if m.subnetPicker.Active {
+		return m.subnetPicker.View(), true
+	}
+	if m.networkCreate.Active {
+		return m.networkCreate.View(), true
+	}
+	if m.subnetCreate.Active {
+		return m.subnetCreate.View(), true
+	}
+	if m.subnetEdit.Active {
+		return m.subnetEdit.View(), true
+	}
+	if m.portCreate.Active {
+		return m.portCreate.View(), true
+	}
+	if m.portEdit.Active {
+		return m.portEdit.View(), true
+	}
+	if m.sgCreate.Active {
+		return m.sgCreate.View(), true
+	}
+	if m.sgRuleCreate.Active {
+		return m.sgRuleCreate.View(), true
+	}
+	if m.imageEdit.Active {
+		return m.imageEdit.View(), true
+	}
+	if m.imageCreate.Active {
+		return m.imageCreate.View(), true
+	}
+	if m.imageDownload.Active {
+		return m.imageDownload.View(), true
+	}
+	if m.lbCreate.Active {
+		return m.lbCreate.View(), true
+	}
+	if m.lbListenerCreate.Active {
+		return m.lbListenerCreate.View(), true
+	}
+	if m.lbPoolCreate.Active {
+		return m.lbPoolCreate.View(), true
+	}
+	if m.lbMemberCreate.Active {
+		return m.lbMemberCreate.View(), true
+	}
+	if m.lbMonitorCreate.Active {
+		return m.lbMonitorCreate.View(), true
+	}
+	if m.projectPicker.Active {
+		return m.projectPicker.View(), true
+	}
+	return "", false
+}
+
+// updateAnyModal routes a key message to the active modal/overlay.
+// Returns true if the message was consumed by a modal.
+func (m *Model) updateAnyModal(msg tea.Msg) (bool, tea.Cmd) {
+	switch {
+	case m.cloneProgress.Active:
+		var cmd tea.Cmd
+		m.cloneProgress, cmd = m.cloneProgress.Update(msg)
+		return true, cmd
+	case m.serverRename.Active:
+		var cmd tea.Cmd
+		m.serverRename, cmd = m.serverRename.Update(msg)
+		return true, cmd
+	case m.serverRebuild.Active:
+		var cmd tea.Cmd
+		m.serverRebuild, cmd = m.serverRebuild.Update(msg)
+		return true, cmd
+	case m.serverSnapshot.Active:
+		var cmd tea.Cmd
+		m.serverSnapshot, cmd = m.serverSnapshot.Update(msg)
+		return true, cmd
+	case m.serverResize.Active:
+		var cmd tea.Cmd
+		m.serverResize, cmd = m.serverResize.Update(msg)
+		return true, cmd
+	case m.sshPrompt.Active:
+		var cmd tea.Cmd
+		m.sshPrompt, cmd = m.sshPrompt.Update(msg)
+		return true, cmd
+	case m.copyPicker.Active:
+		var cmd tea.Cmd
+		m.copyPicker, cmd = m.copyPicker.Update(msg)
+		return true, cmd
+	case m.consoleURL.Active:
+		var cmd tea.Cmd
+		m.consoleURL, cmd = m.consoleURL.Update(msg)
+		return true, cmd
+	case m.vmPassword.Active:
+		var cmd tea.Cmd
+		m.vmPassword, cmd = m.vmPassword.Update(msg)
+		return true, cmd
+	case m.fipPicker.Active:
+		var cmd tea.Cmd
+		m.fipPicker, cmd = m.fipPicker.Update(msg)
+		return true, cmd
+	case m.serverPicker.Active:
+		var cmd tea.Cmd
+		m.serverPicker, cmd = m.serverPicker.Update(msg)
+		return true, cmd
+	case m.volumePicker.Active:
+		var cmd tea.Cmd
+		m.volumePicker, cmd = m.volumePicker.Update(msg)
+		return true, cmd
+	case m.routerCreate.Active:
+		var cmd tea.Cmd
+		m.routerCreate, cmd = m.routerCreate.Update(msg)
+		return true, cmd
+	case m.subnetPicker.Active:
+		var cmd tea.Cmd
+		m.subnetPicker, cmd = m.subnetPicker.Update(msg)
+		return true, cmd
+	case m.networkCreate.Active:
+		var cmd tea.Cmd
+		m.networkCreate, cmd = m.networkCreate.Update(msg)
+		return true, cmd
+	case m.subnetCreate.Active:
+		var cmd tea.Cmd
+		m.subnetCreate, cmd = m.subnetCreate.Update(msg)
+		return true, cmd
+	case m.subnetEdit.Active:
+		var cmd tea.Cmd
+		m.subnetEdit, cmd = m.subnetEdit.Update(msg)
+		return true, cmd
+	case m.portCreate.Active:
+		var cmd tea.Cmd
+		m.portCreate, cmd = m.portCreate.Update(msg)
+		return true, cmd
+	case m.portEdit.Active:
+		var cmd tea.Cmd
+		m.portEdit, cmd = m.portEdit.Update(msg)
+		return true, cmd
+	case m.sgCreate.Active:
+		var cmd tea.Cmd
+		m.sgCreate, cmd = m.sgCreate.Update(msg)
+		return true, cmd
+	case m.sgRuleCreate.Active:
+		var cmd tea.Cmd
+		m.sgRuleCreate, cmd = m.sgRuleCreate.Update(msg)
+		return true, cmd
+	case m.imageEdit.Active:
+		var cmd tea.Cmd
+		m.imageEdit, cmd = m.imageEdit.Update(msg)
+		return true, cmd
+	case m.imageCreate.Active:
+		var cmd tea.Cmd
+		m.imageCreate, cmd = m.imageCreate.Update(msg)
+		return true, cmd
+	case m.imageDownload.Active:
+		var cmd tea.Cmd
+		m.imageDownload, cmd = m.imageDownload.Update(msg)
+		return true, cmd
+	case m.lbCreate.Active:
+		var cmd tea.Cmd
+		m.lbCreate, cmd = m.lbCreate.Update(msg)
+		return true, cmd
+	case m.lbListenerCreate.Active:
+		var cmd tea.Cmd
+		m.lbListenerCreate, cmd = m.lbListenerCreate.Update(msg)
+		return true, cmd
+	case m.lbPoolCreate.Active:
+		var cmd tea.Cmd
+		m.lbPoolCreate, cmd = m.lbPoolCreate.Update(msg)
+		return true, cmd
+	case m.lbMemberCreate.Active:
+		var cmd tea.Cmd
+		m.lbMemberCreate, cmd = m.lbMemberCreate.Update(msg)
+		return true, cmd
+	case m.lbMonitorCreate.Active:
+		var cmd tea.Cmd
+		m.lbMonitorCreate, cmd = m.lbMonitorCreate.Update(msg)
+		return true, cmd
+	case m.projectPicker.Active:
+		var cmd tea.Cmd
+		m.projectPicker, cmd = m.projectPicker.Update(msg)
+		return true, cmd
+	}
+	return false, nil
+}
+
+// updateAnyModalBackground routes non-key messages to active modals.
+func (m *Model) updateAnyModalBackground(msg tea.Msg) tea.Cmd {
+	switch {
+	case m.serverRename.Active:
+		var cmd tea.Cmd
+		m.serverRename, cmd = m.serverRename.Update(msg)
+		return cmd
+	case m.serverRebuild.Active:
+		var cmd tea.Cmd
+		m.serverRebuild, cmd = m.serverRebuild.Update(msg)
+		return cmd
+	case m.serverSnapshot.Active:
+		var cmd tea.Cmd
+		m.serverSnapshot, cmd = m.serverSnapshot.Update(msg)
+		return cmd
+	case m.serverResize.Active:
+		var cmd tea.Cmd
+		m.serverResize, cmd = m.serverResize.Update(msg)
+		return cmd
+	case m.fipPicker.Active:
+		var cmd tea.Cmd
+		m.fipPicker, cmd = m.fipPicker.Update(msg)
+		return cmd
+	case m.serverPicker.Active:
+		var cmd tea.Cmd
+		m.serverPicker, cmd = m.serverPicker.Update(msg)
+		return cmd
+	case m.volumePicker.Active:
+		var cmd tea.Cmd
+		m.volumePicker, cmd = m.volumePicker.Update(msg)
+		return cmd
+	case m.routerCreate.Active:
+		var cmd tea.Cmd
+		m.routerCreate, cmd = m.routerCreate.Update(msg)
+		return cmd
+	case m.subnetPicker.Active:
+		var cmd tea.Cmd
+		m.subnetPicker, cmd = m.subnetPicker.Update(msg)
+		return cmd
+	case m.networkCreate.Active:
+		var cmd tea.Cmd
+		m.networkCreate, cmd = m.networkCreate.Update(msg)
+		return cmd
+	case m.subnetCreate.Active:
+		var cmd tea.Cmd
+		m.subnetCreate, cmd = m.subnetCreate.Update(msg)
+		return cmd
+	case m.subnetEdit.Active:
+		var cmd tea.Cmd
+		m.subnetEdit, cmd = m.subnetEdit.Update(msg)
+		return cmd
+	case m.portCreate.Active:
+		var cmd tea.Cmd
+		m.portCreate, cmd = m.portCreate.Update(msg)
+		return cmd
+	case m.portEdit.Active:
+		var cmd tea.Cmd
+		m.portEdit, cmd = m.portEdit.Update(msg)
+		return cmd
+	case m.sgCreate.Active:
+		var cmd tea.Cmd
+		m.sgCreate, cmd = m.sgCreate.Update(msg)
+		return cmd
+	case m.sgRuleCreate.Active:
+		var cmd tea.Cmd
+		m.sgRuleCreate, cmd = m.sgRuleCreate.Update(msg)
+		return cmd
+	case m.imageEdit.Active:
+		var cmd tea.Cmd
+		m.imageEdit, cmd = m.imageEdit.Update(msg)
+		return cmd
+	case m.imageCreate.Active:
+		var cmd tea.Cmd
+		m.imageCreate, cmd = m.imageCreate.Update(msg)
+		return cmd
+	case m.imageDownload.Active:
+		var cmd tea.Cmd
+		m.imageDownload, cmd = m.imageDownload.Update(msg)
+		return cmd
+	case m.lbCreate.Active:
+		var cmd tea.Cmd
+		m.lbCreate, cmd = m.lbCreate.Update(msg)
+		return cmd
+	case m.lbListenerCreate.Active:
+		var cmd tea.Cmd
+		m.lbListenerCreate, cmd = m.lbListenerCreate.Update(msg)
+		return cmd
+	case m.lbPoolCreate.Active:
+		var cmd tea.Cmd
+		m.lbPoolCreate, cmd = m.lbPoolCreate.Update(msg)
+		return cmd
+	case m.lbMemberCreate.Active:
+		var cmd tea.Cmd
+		m.lbMemberCreate, cmd = m.lbMemberCreate.Update(msg)
+		return cmd
+	case m.lbMonitorCreate.Active:
+		var cmd tea.Cmd
+		m.lbMonitorCreate, cmd = m.lbMonitorCreate.Update(msg)
+		return cmd
+	case m.projectPicker.Active:
+		var cmd tea.Cmd
+		m.projectPicker, cmd = m.projectPicker.Update(msg)
+		return cmd
+	case m.cloneProgress.Running():
+		var cmd tea.Cmd
+		m.cloneProgress, cmd = m.cloneProgress.Update(msg)
+		return cmd
+	}
+	return nil
+}
+
+// setSizeAllModals propagates window size to all modal/overlay models.
+func (m *Model) setSizeAllModals(w, h int) {
+	m.confirm.SetSize(w, h)
+	m.errModal.SetSize(w, h)
+	m.serverRename.SetSize(w, h)
+	m.serverRebuild.SetSize(w, h)
+	m.serverSnapshot.SetSize(w, h)
+	m.serverResize.SetSize(w, h)
+	m.sshPrompt.SetSize(w, h)
+	m.copyPicker.SetSize(w, h)
+	m.consoleURL.SetSize(w, h)
+	m.vmPassword.SetSize(w, h)
+	m.fipPicker.SetSize(w, h)
+	m.serverPicker.SetSize(w, h)
+	m.volumePicker.SetSize(w, h)
+	m.sgCreate.SetSize(w, h)
+	m.sgRuleCreate.SetSize(w, h)
+	m.networkCreate.SetSize(w, h)
+	m.subnetCreate.SetSize(w, h)
+	m.subnetEdit.SetSize(w, h)
+	m.portCreate.SetSize(w, h)
+	m.portEdit.SetSize(w, h)
+	m.routerCreate.SetSize(w, h)
+	m.subnetPicker.SetSize(w, h)
+	m.projectPicker.SetSize(w, h)
+	m.cloneProgress.SetSize(w, h)
+}

--- a/src/internal/app/navstack.go
+++ b/src/internal/app/navstack.go
@@ -1,0 +1,79 @@
+package app
+
+import (
+	"sync"
+)
+
+// NavStack is an explicit navigation stack for back-navigation.
+// Replaces the implicit previousView/returnToView fields on the Model.
+type NavStack struct {
+	mu    sync.Mutex
+	items []NavEntry
+}
+
+// NavEntry represents one navigation point on the stack.
+type NavEntry struct {
+	View activeView // view to restore
+	Tab  int        // active tab to restore, -1 if unchanged
+}
+
+// Push saves the current state. Use before navigating away.
+func (ns *NavStack) Push(view activeView, tab int) {
+	ns.mu.Lock()
+	ns.items = append(ns.items, NavEntry{View: view, Tab: tab})
+	ns.mu.Unlock()
+}
+
+// Pop removes and returns the top entry. Returns (zero, false) on empty stack.
+func (ns *NavStack) Pop() (NavEntry, bool) {
+	ns.mu.Lock()
+	defer ns.mu.Unlock()
+	if len(ns.items) == 0 {
+		return NavEntry{}, false
+	}
+	idx := len(ns.items) - 1
+	entry := ns.items[idx]
+	ns.items = ns.items[:idx]
+	return entry, true
+}
+
+// Peek returns the top entry without removing it.
+func (ns *NavStack) Peek() (NavEntry, bool) {
+	ns.mu.Lock()
+	defer ns.mu.Unlock()
+	if len(ns.items) == 0 {
+		return NavEntry{}, false
+	}
+	return ns.items[len(ns.items)-1], true
+}
+
+// TopView returns the view of the top entry, or 0 if empty.
+func (ns *NavStack) TopView() activeView {
+	ns.mu.Lock()
+	defer ns.mu.Unlock()
+	if len(ns.items) == 0 {
+		return 0
+	}
+	return ns.items[len(ns.items)-1].View
+}
+
+// IsEmpty reports whether the stack has no entries.
+func (ns *NavStack) IsEmpty() bool {
+	ns.mu.Lock()
+	defer ns.mu.Unlock()
+	return len(ns.items) == 0
+}
+
+// Len returns the number of entries in the stack.
+func (ns *NavStack) Len() int {
+	ns.mu.Lock()
+	defer ns.mu.Unlock()
+	return len(ns.items)
+}
+
+// Clear empties the stack.
+func (ns *NavStack) Clear() {
+	ns.mu.Lock()
+	ns.items = nil
+	ns.mu.Unlock()
+}

--- a/src/internal/app/navstack_test.go
+++ b/src/internal/app/navstack_test.go
@@ -1,0 +1,125 @@
+package app
+
+import (
+	"testing"
+)
+
+func TestNavStackPushPop(t *testing.T) {
+	var ns NavStack
+	if !ns.IsEmpty() {
+		t.Fatal("new stack should be empty")
+	}
+	if ns.Len() != 0 {
+		t.Fatal("new stack len should be 0")
+	}
+
+	ns.Push(viewServerList, 0)
+	if ns.IsEmpty() {
+		t.Fatal("stack should not be empty after push")
+	}
+	if ns.Len() != 1 {
+		t.Fatalf("len = %d, want 1", ns.Len())
+	}
+	if ns.TopView() != viewServerList {
+		t.Fatalf("top view = %d, want viewServerList", ns.TopView())
+	}
+
+	entry, ok := ns.Peek()
+	if !ok {
+		t.Fatal("peek should succeed")
+	}
+	if entry.View != viewServerList {
+		t.Fatalf("peeked view = %d, want viewServerList", entry.View)
+	}
+	if entry.Tab != 0 {
+		t.Fatalf("peeked tab = %d, want 0", entry.Tab)
+	}
+	if ns.Len() != 1 {
+		t.Fatal("peek should not remove entry")
+	}
+
+	entry, ok = ns.Pop()
+	if !ok {
+		t.Fatal("pop should succeed")
+	}
+	if entry.View != viewServerList || entry.Tab != 0 {
+		t.Fatal("popped entry mismatch")
+	}
+	if !ns.IsEmpty() {
+		t.Fatal("stack should be empty after pop")
+	}
+}
+
+func TestNavStackPopEmpty(t *testing.T) {
+	var ns NavStack
+	_, ok := ns.Pop()
+	if ok {
+		t.Fatal("pop on empty stack should fail")
+	}
+}
+
+func TestNavStackPeekEmpty(t *testing.T) {
+	var ns NavStack
+	_, ok := ns.Peek()
+	if ok {
+		t.Fatal("peek on empty stack should fail")
+	}
+	if ns.TopView() != 0 {
+		t.Fatal("topView on empty stack should be 0")
+	}
+}
+
+func TestNavStackMultipleItems(t *testing.T) {
+	var ns NavStack
+	ns.Push(viewCloudPicker, -1)
+	ns.Push(viewServerList, 0)
+	ns.Push(viewServerDetail, 2)
+
+	if ns.Len() != 3 {
+		t.Fatalf("len = %d, want 3", ns.Len())
+	}
+
+	// LIFO order
+	e1, _ := ns.Pop()
+	if e1.View != viewServerDetail || e1.Tab != 2 {
+		t.Fatalf("pop 1 = %d/%d, want viewServerDetail/2", e1.View, e1.Tab)
+	}
+	e2, _ := ns.Pop()
+	if e2.View != viewServerList || e2.Tab != 0 {
+		t.Fatalf("pop 2 = %d/%d, want viewServerList/0", e2.View, e2.Tab)
+	}
+	e3, _ := ns.Pop()
+	if e3.View != viewCloudPicker || e3.Tab != -1 {
+		t.Fatalf("pop 3 = %d/%d, want viewCloudPicker/-1", e3.View, e3.Tab)
+	}
+}
+
+func TestNavStackClear(t *testing.T) {
+	var ns NavStack
+	ns.Push(viewServerList, 0)
+	ns.Push(viewServerDetail, 0)
+	ns.Clear()
+	if !ns.IsEmpty() {
+		t.Fatal("stack should be empty after clear")
+	}
+	if ns.Len() != 0 {
+		t.Fatal("len should be 0 after clear")
+	}
+}
+
+func TestNavStackThreadSafety(t *testing.T) {
+	var ns NavStack
+	done := make(chan bool)
+	for i := 0; i < 100; i++ {
+		go func() {
+			for j := 0; j < 100; j++ {
+				ns.Push(viewServerList, 0)
+				ns.Pop()
+			}
+			done <- true
+		}()
+	}
+	for i := 0; i < 100; i++ {
+		<-done
+	}
+}

--- a/src/internal/app/render.go
+++ b/src/internal/app/render.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/larkly/lazystack/internal/shared"
 	"charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/larkly/lazystack/internal/shared"
 )
 
 func (m Model) viewName() string {
@@ -78,103 +78,8 @@ func (m Model) viewContent() string {
 		return m.help.Render()
 	}
 
-	// Overlay priority chain — overlays are mutually exclusive by design
-	// (each action activates at most one), so first-match ordering is safe.
-	if m.activeModal == modalConfirm {
-		return m.confirm.View()
-	}
-	if m.activeModal == modalError {
-		return m.errModal.View()
-	}
-	if m.fipPicker.Active {
-		return m.fipPicker.View()
-	}
-	if m.serverPicker.Active {
-		return m.serverPicker.View()
-	}
-	if m.volumePicker.Active {
-		return m.volumePicker.View()
-	}
-	if m.routerCreate.Active {
-		return m.routerCreate.View()
-	}
-	if m.subnetPicker.Active {
-		return m.subnetPicker.View()
-	}
-	if m.networkCreate.Active {
-		return m.networkCreate.View()
-	}
-	if m.subnetCreate.Active {
-		return m.subnetCreate.View()
-	}
-	if m.subnetEdit.Active {
-		return m.subnetEdit.View()
-	}
-	if m.portCreate.Active {
-		return m.portCreate.View()
-	}
-	if m.portEdit.Active {
-		return m.portEdit.View()
-	}
-	if m.sgCreate.Active {
-		return m.sgCreate.View()
-	}
-	if m.sgRuleCreate.Active {
-		return m.sgRuleCreate.View()
-	}
-	if m.imageEdit.Active {
-		return m.imageEdit.View()
-	}
-	if m.imageCreate.Active {
-		return m.imageCreate.View()
-	}
-	if m.imageDownload.Active {
-		return m.imageDownload.View()
-	}
-	if m.lbCreate.Active {
-		return m.lbCreate.View()
-	}
-	if m.lbListenerCreate.Active {
-		return m.lbListenerCreate.View()
-	}
-	if m.lbPoolCreate.Active {
-		return m.lbPoolCreate.View()
-	}
-	if m.lbMemberCreate.Active {
-		return m.lbMemberCreate.View()
-	}
-	if m.lbMonitorCreate.Active {
-		return m.lbMonitorCreate.View()
-	}
-	if m.projectPicker.Active {
-		return m.projectPicker.View()
-	}
-	if m.serverRename.Active {
-		return m.serverRename.View()
-	}
-	if m.serverRebuild.Active {
-		return m.serverRebuild.View()
-	}
-	if m.serverSnapshot.Active {
-		return m.serverSnapshot.View()
-	}
-	if m.serverResize.Active {
-		return m.serverResize.View()
-	}
-	if m.cloneProgress.Active {
-		return m.cloneProgress.View()
-	}
-	if m.sshPrompt.Active {
-		return m.sshPrompt.View()
-	}
-	if m.copyPicker.Active {
-		return m.copyPicker.View()
-	}
-	if m.consoleURL.Active {
-		return m.consoleURL.View()
-	}
-	if m.vmPassword.Active {
-		return m.vmPassword.View()
+	if v, ok := m.activeModalView(); ok {
+		return v
 	}
 
 	var content string

--- a/src/internal/app/routing.go
+++ b/src/internal/app/routing.go
@@ -3,11 +3,11 @@ package app
 import (
 	"time"
 
+	"charm.land/bubbletea/v2"
 	"github.com/larkly/lazystack/internal/shared"
 	"github.com/larkly/lazystack/internal/ui/servercreate"
 	"github.com/larkly/lazystack/internal/ui/serverdetail"
 	"github.com/larkly/lazystack/internal/ui/volumedetail"
-	"charm.land/bubbletea/v2"
 )
 
 // refreshTickCmd returns a single tea.Tick that fires shared.TickMsg after
@@ -174,7 +174,7 @@ func (m Model) handleDetailNavigation(msg shared.NavigateToDetailMsg) (Model, te
 	case "volume":
 		m.volumeDetail = volumedetail.New(m.client.BlockStorage, m.client.Compute, msg.ID)
 		m.volumeDetail.SetSize(m.width, m.height)
-		m.returnToView = m.view
+		m.nav.Push(m.view, m.activeTab)
 		m.view = viewVolumeDetail
 		m.statusBar.CurrentView = "volumedetail"
 		m.statusBar.Hint = m.volumeDetail.Hints()
@@ -254,19 +254,11 @@ func (m Model) handleViewChange(msg shared.ViewChangeMsg) (Model, tea.Cmd) {
 		return m, func() tea.Msg { return shared.RefreshServersMsg{} }
 
 	case "serverdetail":
-		// If coming back from console/resize, return to previous view
-		if m.view == viewConsoleLog || m.view == viewActionLog {
-			if m.previousView == viewServerDetail && m.serverDetail.ServerID() != "" {
-				m.view = viewServerDetail
-				m.statusBar.CurrentView = "serverdetail"
-				m.statusBar.Hint = m.serverDetail.Hints()
-				return m, m.serverDetail.Init()
-			}
-			// Came from list or no valid detail, go to list
-			m.view = viewServerList
-			m.statusBar.CurrentView = "serverlist"
-			m.statusBar.Hint = m.serverList.Hints()
-			return m, func() tea.Msg { return shared.RefreshServersMsg{} }
+		if entry, ok := m.nav.Pop(); ok {
+			m.view = entry.View
+			m.activeTab = entry.Tab
+			m.statusBar.CurrentView = m.viewName()
+			return m, nil
 		}
 		if s := m.serverList.SelectedServer(); s != nil {
 			m.serverDetail = serverdetail.New(m.client.Compute, m.client.Network, m.client.BlockStorage, s.ID, m.refreshInterval)


### PR DESCRIPTION
## Summary

Addresses C3 and H2 from the code review:

- **C3 — Consolidated modal dispatch:** ~25 duplicated if-chains in `Update()` and `View()` replaced by shared helper methods (`modal.go`)
- **H2 — Explicit navigation stack:** `NavStack` replaces implicit `previousView`/`returnToView` fields

## Changes

### `modal.go` (new)
- `isAnyModalActive()` — single check replacing duplicated active-scanning
- `activeModalView()` — single view-rendering method for all modals
- `updateAnyModal()` — single key-message routing for all modals
- `updateAnyModalBackground()` — background message routing (spinner, loaded msgs)
- `setSizeAllModals()` — window-size propagation to all modals

### `navstack.go` (new) + `navstack_test.go` (new)
- LIFO navigation stack with `Push`/`Pop`/`Peek`/`Clear`
- Thread-safe (`sync.Mutex`)
- Tests for ordering, empty-state, concurrency safety

### `app.go`
- `tea.WindowSizeMsg` handler uses `setSizeAllModals()` (replaces 28 individual `SetSize` calls)
- `tea.KeyMsg` handler uses `updateAnyModal()` (replaces ~170 lines of identical if-blocks)
- Default case uses `updateAnyModalBackground()` (replaces ~160 lines of identical if-blocks)

### `render.go`
- `viewContent()` uses `activeModalView()` (replaces ~70 lines of identical if-blocks)

### `routing.go` / `actions_server.go`
- `openConsoleLog`/`openActionLog` push to NavStack instead of setting `previousView`
- `handleDetailNavigation` (volume) pushes to NavStack instead of setting `returnToView`
- `handleViewChange("serverdetail")` pops from NavStack

## Verification

```bash
$ go build ./...  # compiles clean
$ go test ./...   # 16/16 packages pass (1 new: navstack_test.go)
```

No behavioral changes — purely structural refactoring.