### PR TITLE
fix(volume): preserve full attachment state for multiattach volumes (#144)

### DIFF
--- a/src/internal/app/actions_server.go
+++ b/src/internal/app/actions_server.go
@@ -798,14 +798,21 @@ func (m Model) executeAction(action modal.ConfirmAction) (Model, tea.Cmd) {
 				shared.Debugf("[action] detach volume %s failed: %s", name, err)
 				return shared.ResourceActionErrMsg{Action: "Detach volume", Name: name, Err: err}
 			}
-			if vol.AttachedServerID == "" {
+			if !vol.IsAttached() {
 				shared.Debugf("[action] detach volume %s failed: volume is not attached", name)
 				return shared.ResourceActionErrMsg{Action: "Detach volume", Name: name, Err: fmt.Errorf("volume is not attached")}
 			}
-			err = volume.DetachVolume(context.Background(), computeC, vol.AttachedServerID, volID)
-			if err != nil {
-				shared.Debugf("[action] detach volume %s failed: %s", name, err)
-				return shared.ResourceActionErrMsg{Action: "Detach volume", Name: name, Err: err}
+			var detachErrs []error
+			for _, att := range vol.Attachments {
+				err = volume.DetachVolume(context.Background(), computeC, att.ServerID, volID)
+				if err != nil {
+					shared.Debugf("[action] detach volume %s from server %s failed: %s", name, att.ServerID, err)
+					detachErrs = append(detachErrs, fmt.Errorf("server %s: %w", att.ServerID, err))
+				}
+			}
+			if len(detachErrs) > 0 {
+				shared.Debugf("[action] detach volume %s partially failed: %v", name, detachErrs)
+				return shared.ResourceActionErrMsg{Action: "Detach volume", Name: name, Err: fmt.Errorf("detach errors: %v", detachErrs)}
 			}
 			shared.Debugf("[action] detached volume %s", name)
 			return shared.ResourceActionMsg{Action: "Detached volume", Name: name}

--- a/src/internal/volume/volumes.go
+++ b/src/internal/volume/volumes.go
@@ -12,6 +12,12 @@ import (
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
 
+// VolumeAttachment represents a single volume-to-server attachment.
+type VolumeAttachment struct {
+	ServerID string
+	Device   string
+}
+
 // Volume is a simplified block storage volume.
 type Volume struct {
 	ID               string
@@ -23,14 +29,41 @@ type Volume struct {
 	Bootable         string
 	Encrypted        bool
 	Multiattach      bool
-	AttachedServerID string
-	AttachedDevice   string
+	AttachedServerID string             // DEPRECATED: use Attachments + ServerID() instead
+	AttachedDevice   string             // DEPRECATED: use Attachments + Device() instead
+	Attachments      []VolumeAttachment // all current attachments (multiattach-aware)
 	Created          time.Time
 	Updated          time.Time
 	Description      string
 	Metadata         map[string]string
 	SnapshotID       string
 	SourceVolID      string
+}
+
+// ServerID returns the first attachment's server ID for backward compatibility.
+func (v Volume) ServerID() string {
+	if len(v.Attachments) > 0 {
+		return v.Attachments[0].ServerID
+	}
+	return ""
+}
+
+// Device returns the first attachment's device path for backward compatibility.
+func (v Volume) Device() string {
+	if len(v.Attachments) > 0 {
+		return v.Attachments[0].Device
+	}
+	return ""
+}
+
+// IsAttached returns whether the volume has any attachments.
+func (v Volume) IsAttached() bool {
+	return len(v.Attachments) > 0
+}
+
+// IsMultiAttached returns whether the volume is attached to multiple servers.
+func (v Volume) IsMultiAttached() bool {
+	return len(v.Attachments) > 1
 }
 
 // ListVolumes fetches all volumes.
@@ -60,10 +93,11 @@ func ListVolumes(ctx context.Context, client *gophercloud.ServiceClient) ([]Volu
 				SnapshotID:  v.SnapshotID,
 				SourceVolID: v.SourceVolID,
 			}
-			if len(v.Attachments) > 0 {
-				vol.AttachedServerID = v.Attachments[0].ServerID
-				vol.AttachedDevice = v.Attachments[0].Device
+			for _, att := range v.Attachments {
+				vol.Attachments = append(vol.Attachments, VolumeAttachment{ServerID: att.ServerID, Device: att.Device})
 			}
+			vol.AttachedServerID = vol.ServerID()
+			vol.AttachedDevice = vol.Device()
 			result = append(result, vol)
 		}
 		return true, nil
@@ -101,10 +135,11 @@ func GetVolume(ctx context.Context, client *gophercloud.ServiceClient, id string
 		SnapshotID:  v.SnapshotID,
 		SourceVolID: v.SourceVolID,
 	}
-	if len(v.Attachments) > 0 {
-		vol.AttachedServerID = v.Attachments[0].ServerID
-		vol.AttachedDevice = v.Attachments[0].Device
+	for _, att := range v.Attachments {
+		vol.Attachments = append(vol.Attachments, VolumeAttachment{ServerID: att.ServerID, Device: att.Device})
 	}
+	vol.AttachedServerID = vol.ServerID()
+	vol.AttachedDevice = vol.Device()
 	shared.Debugf("[volume] GetVolume: success, id=%s name=%s", vol.ID, vol.Name)
 	return vol, nil
 }


### PR DESCRIPTION
## Summary
Preserve the full attachment state for multiattach-capable volumes instead of only tracking the first attachment.

## Changes
- Add `VolumeAttachment` struct with `ServerID` and `Device` fields
- Add `Attachments []VolumeAttachment` field to `Volume` struct (multiattach-aware)
- Add helper methods: `ServerID()`, `Device()`, `IsAttached()`, `IsMultiAttached()`
- Update `ListVolumes` and `GetVolume` to preserve all attachments in the slice
- Populate deprecated `AttachedServerID`/`AttachedDevice` fields via methods for UI backward compatibility
- Update detach action to iterate and detach from all attached servers

## Testing
- `go build ./...` — passes
- `go test ./...` — all tests pass

Closes #144