### PR TITLE
fix(cloud): negotiate Nova microversion instead of hard-coding 2.100 (#59)

### DIFF
--- a/src/internal/cloud/client.go
+++ b/src/internal/cloud/client.go
@@ -3,7 +3,10 @@ package cloud
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/larkly/lazystack/internal/shared"
 
@@ -13,17 +16,108 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/config/clouds"
 )
 
+// negotiateNovaMicroversion queries the Nova API for the max supported microversion,
+// caps at 2.100 (our known-good ceiling), and returns the negotiated version.
+// Returns (maxVersion, usedVersion, degradationWarning).
+func negotiateNovaMicroversion(ctx context.Context, compute *gophercloud.ServiceClient) (string, string, string) {
+	const ceiling = "2.100"
+
+	// Save current microversion and set to base for version discovery
+	// Version discovery returns the API versions supported by the deployment.
+	url := compute.ServiceURL("")
+	resp, err := compute.Get(ctx, url, nil, &gophercloud.RequestOpts{
+		// Version discovery does not need a microversion
+	})
+	if err != nil {
+		shared.Debugf("[cloud] negotiateMicroversion: version discovery failed: %v, falling back to %s", err, ceiling)
+		return "unknown", ceiling, ""
+	}
+
+	var versionDoc struct {
+		Versions []struct {
+			ID         string `json:"id"`
+			Version    string `json:"version"`
+			MinVersion string `json:"min_version"`
+		} `json:"versions"`
+		Version struct {
+			ID      string `json:"id"`
+			Version string `json:"version"`
+		} `json:"version"`
+	}
+
+	defer resp.Body.Close()
+	if err := json.NewDecoder(resp.Body).Decode(&versionDoc); err != nil {
+		shared.Debugf("[cloud] negotiateMicroversion: JSON parse failed: %v, falling back to %s", err, ceiling)
+		return "unknown", ceiling, ""
+	}
+
+	// Parse the latest supported version from the response
+	// Nova version document has versions array with IDs like "v2.1"
+	// "version" field = max supported microversion, "min_version" = minimum
+	maxVersion := "unknown"
+	for _, v := range versionDoc.Versions {
+		if v.ID == "v2.1" {
+			maxVersion = v.Version
+			break
+		}
+	}
+
+	// If we couldn't parse it, fall back
+	if maxVersion == "" || maxVersion == "unknown" {
+		shared.Debugf("[cloud] negotiateMicroversion: couldn't determine max version, using %s", ceiling)
+		return "unknown", ceiling, ""
+	}
+
+	// Compare: use the lower of maxVersion and ceiling (2.100)
+	usedVersion := minMicroversion(maxVersion, ceiling)
+	degradeWarning := ""
+	if usedVersion != ceiling {
+		degradeWarning = fmt.Sprintf(
+			"Nova microversion %s (max supported: %s, requested: %s). Some features may be limited."+
+				" Upgrade to OpenStack Zed (2023.1) or later for full functionality.",
+			usedVersion, maxVersion, ceiling,
+		)
+		shared.Debugf("[cloud] negotiateMicroversion: degraded: %s", degradeWarning)
+	}
+
+	return maxVersion, usedVersion, degradeWarning
+}
+
+// minMicroversion returns the numerically lower of two microversion strings.
+// Microversions are formatted as "X.Y" — compare major then minor.
+func minMicroversion(a, b string) string {
+	ma, mi := parseMicroversion(a)
+	mb, mj := parseMicroversion(b)
+
+	if ma > mb || (ma == mb && mi > mj) {
+		return b
+	}
+	return a
+}
+
+func parseMicroversion(v string) (int, int) {
+	parts := strings.Split(v, ".")
+	if len(parts) < 2 {
+		return 0, 0
+	}
+	ma, _ := strconv.Atoi(parts[0])
+	mi, _ := strconv.Atoi(parts[1])
+	return ma, mi
+}
+
 // Client holds authenticated OpenStack service clients.
 type Client struct {
-	CloudName      string
-	Region         string
-	Compute        *gophercloud.ServiceClient
-	Image          *gophercloud.ServiceClient
-	Network        *gophercloud.ServiceClient
-	BlockStorage   *gophercloud.ServiceClient
-	LoadBalancer   *gophercloud.ServiceClient
-	ProviderClient *gophercloud.ProviderClient
-	EndpointOpts   gophercloud.EndpointOpts
+	CloudName            string
+	Region               string
+	Compute              *gophercloud.ServiceClient
+	Image                *gophercloud.ServiceClient
+	Network              *gophercloud.ServiceClient
+	BlockStorage         *gophercloud.ServiceClient
+	LoadBalancer         *gophercloud.ServiceClient
+	ProviderClient       *gophercloud.ProviderClient
+	EndpointOpts         gophercloud.EndpointOpts
+	NovaMicroversionMax  string // max supported by this deployment
+	NovaMicroversionUsed string // actual microversion in use (≤ 2.100)
 }
 
 // Connect authenticates to the given cloud and initializes service clients.
@@ -66,6 +160,10 @@ func connectWithOpts(ctx context.Context, ao gophercloud.AuthOptions, eo gopherc
 	}
 	compute.Microversion = "2.100"
 
+	// Negotiate the actual Nova microversion supported by this deployment.
+	maxVersion, usedVersion, degradeWarning := negotiateNovaMicroversion(ctx, compute)
+	compute.Microversion = usedVersion
+
 	shared.Debugf("[cloud] connectWithOpts: creating image client")
 	image, err := openstack.NewImageV2(providerClient, eo)
 	if err != nil {
@@ -100,17 +198,22 @@ func connectWithOpts(ctx context.Context, ao gophercloud.AuthOptions, eo gopherc
 		region = "default"
 	}
 
-	shared.Debugf("[cloud] connectWithOpts: success, cloud=%s region=%s", cloudName, region)
+	shared.Debugf("[cloud] connectWithOpts: success, cloud=%s region=%s nova_version=%s (max=%s)", cloudName, region, usedVersion, maxVersion)
+	if degradeWarning != "" {
+		shared.Debugf("[cloud] connectWithOpts: degradation warning: %s", degradeWarning)
+	}
 	return &Client{
-		CloudName:      cloudName,
-		Region:         region,
-		Compute:        compute,
-		Image:          image,
-		Network:        network,
-		BlockStorage:   blockStorage,
-		LoadBalancer:   loadBalancer,
-		ProviderClient: providerClient,
-		EndpointOpts:   eo,
+		CloudName:            cloudName,
+		Region:               region,
+		Compute:              compute,
+		Image:                image,
+		Network:              network,
+		BlockStorage:         blockStorage,
+		LoadBalancer:         loadBalancer,
+		ProviderClient:       providerClient,
+		EndpointOpts:         eo,
+		NovaMicroversionMax:  maxVersion,
+		NovaMicroversionUsed: usedVersion,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
Replace the hard-coded Nova microversion (2.100) with runtime microversion negotiation that queries the Nova API for the max supported version, caps at 2.100, and gracefully degrades on older deployments.

## Changes
- Add `NovaMicroversionMax` and `NovaMicroversionUsed` fields to `cloud.Client` struct
- Add `negotiateNovaMicroversion()` to query the Nova root endpoint and parse supported versions
- Add `minMicroversion()` and `parseMicroversion()` helpers for version comparison
- Replace hard-coded `compute.Microversion = "2.100"` with the negotiated version
- Log degradation warning when running on pre-Zed OpenStack deployments

## Testing
- `go build ./...` — passes
- `go test ./...` — all tests pass
- `go vet ./internal/cloud/...` — clean

Closes #59