### PR TITLE
feat(admin): add admin server actions and metadata browser (#31 Phase 6)

### DIFF
--- a/src/internal/app/actions_server.go
+++ b/src/internal/app/actions_server.go
@@ -22,12 +22,14 @@ import (
 	"github.com/larkly/lazystack/internal/ui/fippicker"
 	"github.com/larkly/lazystack/internal/ui/hypervisorlist"
 	"github.com/larkly/lazystack/internal/ui/modal"
+	"github.com/larkly/lazystack/internal/ui/serveradminact"
 	"github.com/larkly/lazystack/internal/ui/servercreate"
 	"github.com/larkly/lazystack/internal/ui/serverrebuild"
 	"github.com/larkly/lazystack/internal/ui/serverrename"
 	"github.com/larkly/lazystack/internal/ui/serverresize"
 	"github.com/larkly/lazystack/internal/ui/serversnapshot"
 	"github.com/larkly/lazystack/internal/ui/servicecatalog"
+	"github.com/larkly/lazystack/internal/ui/servermetadata"
 	"github.com/larkly/lazystack/internal/ui/sshprompt"
 	"github.com/larkly/lazystack/internal/volume"
 )
@@ -1315,4 +1317,40 @@ func (m Model) openConsoleURL() (Model, tea.Cmd) {
 		}
 		return shared.ConsoleURLMsg{URL: url, ServerName: serverName}
 	}
+}
+
+func (m Model) openAdminActions() (Model, tea.Cmd) {
+	var id, name string
+	if m.view == viewServerDetail {
+		id = m.serverDetail.ServerID()
+		name = m.serverDetail.ServerName()
+	}
+	if id == "" {
+		return m, nil
+	}
+	m.serverAdminAct = serveradminact.New(m.client.Compute, id, name)
+	m.serverAdminAct.SetSize(m.width, m.height)
+	return m, m.serverAdminAct.Init()
+}
+
+func (m Model) openServerMetadata() (Model, tea.Cmd) {
+	var id, name string
+	var meta map[string]string
+	if m.view == viewServerDetail {
+		id = m.serverDetail.ServerID()
+		name = m.serverDetail.ServerName()
+		s := m.serverDetail.Server()
+		if s != nil {
+			meta = s.Metadata
+		}
+	}
+	if id == "" {
+		return m, nil
+	}
+	if meta == nil {
+		meta = make(map[string]string)
+	}
+	m.serverMetadata = servermetadata.New(m.client.Compute, id, name, meta)
+	m.serverMetadata.SetSize(m.width, m.height)
+	return m, m.serverMetadata.Init()
 }

--- a/src/internal/app/app.go
+++ b/src/internal/app/app.go
@@ -51,10 +51,12 @@ import (
 	"github.com/larkly/lazystack/internal/ui/routercreate"
 	"github.com/larkly/lazystack/internal/ui/routerview"
 	"github.com/larkly/lazystack/internal/ui/secgroupview"
+	"github.com/larkly/lazystack/internal/ui/serveradminact"
 	"github.com/larkly/lazystack/internal/ui/servercreate"
 	"github.com/larkly/lazystack/internal/ui/serverdetail"
 	"github.com/larkly/lazystack/internal/ui/serverlist"
 	"github.com/larkly/lazystack/internal/ui/servicecatalog"
+	"github.com/larkly/lazystack/internal/ui/servermetadata"
 	"github.com/larkly/lazystack/internal/ui/serverpicker"
 	"github.com/larkly/lazystack/internal/ui/serverrebuild"
 	"github.com/larkly/lazystack/internal/ui/serverrename"
@@ -140,6 +142,8 @@ type Model struct {
 	serverRebuild       serverrebuild.Model
 	serverSnapshot      serversnapshot.Model
 	serverResize        serverresize.Model
+	serverAdminAct      serveradminact.Model
+	serverMetadata      servermetadata.Model
 	sshPrompt           sshprompt.Model
 	consoleURL          consoleurl.Model
 	vmPassword          vmpassword.Model
@@ -535,6 +539,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if key.Matches(msg, shared.Keys.Snapshot) {
 				return m.openSnapshot()
+			}
+			if key.Matches(msg, shared.Keys.AdminActions) {
+				return m.openAdminActions()
+			}
+			if key.Matches(msg, shared.Keys.Metadata) {
+				return m.openServerMetadata()
 			}
 			if key.Matches(msg, shared.Keys.ConfirmResize) {
 				return m.doConfirmResize()

--- a/src/internal/app/modal.go
+++ b/src/internal/app/modal.go
@@ -12,6 +12,8 @@ func (m *Model) isAnyModalActive() bool {
 		m.serverRebuild.Active ||
 		m.serverSnapshot.Active ||
 		m.serverResize.Active ||
+		m.serverAdminAct.Active ||
+		m.serverMetadata.Active ||
 		m.sshPrompt.Active ||
 		m.copyPicker.Active ||
 		m.consoleURL.Active ||
@@ -62,6 +64,12 @@ func (m *Model) activeModalView() (string, bool) {
 	}
 	if m.serverResize.Active {
 		return m.serverResize.View(), true
+	}
+	if m.serverAdminAct.Active {
+		return m.serverAdminAct.View(), true
+	}
+	if m.serverMetadata.Active {
+		return m.serverMetadata.View(), true
 	}
 	if m.sshPrompt.Active {
 		return m.sshPrompt.View(), true
@@ -164,6 +172,14 @@ func (m *Model) updateAnyModal(msg tea.Msg) (bool, tea.Cmd) {
 	case m.serverResize.Active:
 		var cmd tea.Cmd
 		m.serverResize, cmd = m.serverResize.Update(msg)
+		return true, cmd
+	case m.serverAdminAct.Active:
+		var cmd tea.Cmd
+		m.serverAdminAct, cmd = m.serverAdminAct.Update(msg)
+		return true, cmd
+	case m.serverMetadata.Active:
+		var cmd tea.Cmd
+		m.serverMetadata, cmd = m.serverMetadata.Update(msg)
 		return true, cmd
 	case m.sshPrompt.Active:
 		var cmd tea.Cmd

--- a/src/internal/compute/servers.go
+++ b/src/internal/compute/servers.go
@@ -366,6 +366,73 @@ func RenameServer(ctx context.Context, client *gophercloud.ServiceClient, id, ne
 	return nil
 }
 
+// MigrateServer cold-migrates a server to a new compute host.
+func MigrateServer(ctx context.Context, client *gophercloud.ServiceClient, id string) error {
+	shared.Debugf("[compute] migrating server %s", id)
+	r := servers.Migrate(ctx, client, id)
+	if r.Err != nil {
+		shared.Debugf("[compute] migrate server %s: %v", id, r.Err)
+		return fmt.Errorf("migrating server %s: %w", id, r.Err)
+	}
+	shared.Debugf("[compute] migrated server %s", id)
+	return nil
+}
+
+// LiveMigrateServer live-migrates a server to a target host.
+func LiveMigrateServer(ctx context.Context, client *gophercloud.ServiceClient, id, host string) error {
+	shared.Debugf("[compute] live-migrating server %s to host %s", id, host)
+	opts := servers.LiveMigrateOpts{Host: &host, BlockMigration: new(bool)}
+	*opts.BlockMigration = false
+	r := servers.LiveMigrate(ctx, client, id, opts)
+	if r.Err != nil {
+		shared.Debugf("[compute] live-migrate server %s: %v", id, r.Err)
+		return fmt.Errorf("live-migrating server %s: %w", id, r.Err)
+	}
+	shared.Debugf("[compute] live-migrated server %s", id)
+	return nil
+}
+
+// EvacuateServer evacuates a server from a failed host.
+func EvacuateServer(ctx context.Context, client *gophercloud.ServiceClient, id, targetHost string, onSharedStorage bool) (string, error) {
+	shared.Debugf("[compute] evacuating server %s to %s (shared=%v)", id, targetHost, onSharedStorage)
+	adminPass := ""
+	opts := servers.EvacuateOpts{
+		Host:            targetHost,
+		OnSharedStorage: onSharedStorage,
+	}
+	r := servers.Evacuate(ctx, client, id, opts)
+	if r.Err != nil {
+		shared.Debugf("[compute] evacuate server %s: %v", id, r.Err)
+		return "", fmt.Errorf("evacuating server %s: %w", id, r.Err)
+	}
+	shared.Debugf("[compute] evacuated server %s", id)
+	return adminPass, nil
+}
+
+// ForceDeleteServer forcefully deletes a server.
+func ForceDeleteServer(ctx context.Context, client *gophercloud.ServiceClient, id string) error {
+	shared.Debugf("[compute] force-deleting server %s", id)
+	r := servers.ForceDelete(ctx, client, id)
+	if r.Err != nil {
+		shared.Debugf("[compute] force-delete server %s: %v", id, r.Err)
+		return fmt.Errorf("force-deleting server %s: %w", id, r.Err)
+	}
+	shared.Debugf("[compute] force-deleted server %s", id)
+	return nil
+}
+
+// ResetServerState resets the state of a server.
+func ResetServerState(ctx context.Context, client *gophercloud.ServiceClient, id string, state string) error {
+	shared.Debugf("[compute] resetting state of server %s to %s", id, state)
+	r := servers.ResetState(ctx, client, id, servers.ServerState(state))
+	if r.Err != nil {
+		shared.Debugf("[compute] reset state server %s: %v", id, r.Err)
+		return fmt.Errorf("resetting state of server %s: %w", id, r.Err)
+	}
+	shared.Debugf("[compute] reset state of server %s to %s", id, state)
+	return nil
+}
+
 // GetRemoteConsole retrieves a noVNC console URL for a server.
 func GetRemoteConsole(ctx context.Context, client *gophercloud.ServiceClient, id string) (string, error) {
 	shared.Debugf("[compute] getting remote console for server %s", id)

--- a/src/internal/shared/keys.go
+++ b/src/internal/shared/keys.go
@@ -63,6 +63,8 @@ type KeyMap struct {
 	SaveFilter   key.Binding
 	LoadFilter   key.Binding
 	Browse       key.Binding
+	AdminActions key.Binding
+	Metadata     key.Binding
 }
 
 var Keys = KeyMap{
@@ -305,5 +307,13 @@ var Keys = KeyMap{
 	Browse: key.NewBinding(
 		key.WithKeys("B"),
 		key.WithHelp("B", "browse catalog"),
+	),
+	AdminActions: key.NewBinding(
+		key.WithKeys("A"),
+		key.WithHelp("A", "admin actions"),
+	),
+	Metadata: key.NewBinding(
+		key.WithKeys("M"),
+		key.WithHelp("M", "metadata"),
 	),
 }

--- a/src/internal/ui/serveradminact/serveradminact.go
+++ b/src/internal/ui/serveradminact/serveradminact.go
@@ -1,0 +1,387 @@
+package serveradminact
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/spinner"
+	"charm.land/bubbles/v2/textinput"
+	"charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/larkly/lazystack/internal/compute"
+	"github.com/larkly/lazystack/internal/shared"
+)
+
+type adminAction struct {
+	label     string
+	apiAction string
+	needsHost bool
+}
+
+var adminActions = []adminAction{
+	{"Cold Migrate", "Migrate", false},
+	{"Live Migrate", "Live Migrate", true},
+	{"Evacuate", "Evacuate", true},
+	{"Force Delete", "Force Delete", false},
+	{"Reset State", "Reset State", false},
+}
+
+var serverStates = []string{"active", "error"}
+
+type actionDoneMsg struct {
+	action string
+	name   string
+}
+
+type actionErrMsg struct {
+	action string
+	name   string
+	err    error
+}
+
+// Model is the admin server actions modal.
+type Model struct {
+	Active       bool
+	client       *gophercloud.ServiceClient
+	serverID     string
+	serverName   string
+	width        int
+	height       int
+	cursor       int
+	promptStage  string // "" = picking, "host" = entering host, "state" = picking state, "confirm" = confirming
+	stateCursor  int
+	hostInput    textinput.Model
+	submitting   bool
+	err          string
+	spinner      spinner.Model
+}
+
+// New creates an admin actions modal.
+func New(client *gophercloud.ServiceClient, serverID, serverName string) Model {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+
+	hi := textinput.New()
+	hi.Prompt = "Host: "
+	hi.Placeholder = "compute-host-01"
+	hi.CharLimit = 255
+
+	return Model{
+		Active:     true,
+		client:     client,
+		serverID:   serverID,
+		serverName: serverName,
+		hostInput:  hi,
+		spinner:    s,
+	}
+}
+
+// Init initializes the model.
+func (m Model) Init() tea.Cmd {
+	return m.spinner.Tick
+}
+
+// Update handles messages.
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case actionDoneMsg:
+		m.submitting = false
+		m.Active = false
+		return m, func() tea.Msg {
+			return shared.ServerActionMsg{Action: msg.action, Name: msg.name}
+		}
+
+	case actionErrMsg:
+		m.submitting = false
+		m.err = fmt.Sprintf("%s %s: %v", msg.action, msg.name, msg.err)
+		return m, nil
+
+	case spinner.TickMsg:
+		if m.submitting {
+			var cmd tea.Cmd
+			m.spinner, cmd = m.spinner.Update(msg)
+			return m, cmd
+		}
+		return m, nil
+
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	}
+	return m, nil
+}
+
+func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
+	if m.submitting {
+		return m, nil
+	}
+
+	if key.Matches(msg, shared.Keys.Back) {
+		if m.promptStage != "" {
+			m.promptStage = ""
+			m.err = ""
+			return m, nil
+		}
+		m.Active = false
+		return m, nil
+	}
+
+	switch m.promptStage {
+	case "":
+		switch {
+		case key.Matches(msg, shared.Keys.Up):
+			m.cursor--
+			if m.cursor < 0 {
+				m.cursor = len(adminActions) - 1
+			}
+		case key.Matches(msg, shared.Keys.Down):
+			m.cursor++
+			if m.cursor >= len(adminActions) {
+				m.cursor = 0
+			}
+		case key.Matches(msg, shared.Keys.Enter):
+			return m, m.enterAction()
+		}
+
+	case "host":
+		switch {
+		case key.Matches(msg, shared.Keys.Enter):
+			host := strings.TrimSpace(m.hostInput.Value())
+			if host == "" {
+				m.err = "Host name is required"
+				return m, nil
+			}
+			m.submitting = true
+			m.err = ""
+			return m, m.executeWithHost(host)
+		default:
+			var cmd tea.Cmd
+			m.hostInput, cmd = m.hostInput.Update(msg)
+			return m, cmd
+		}
+
+	case "state":
+		switch {
+		case key.Matches(msg, shared.Keys.Up):
+			m.stateCursor--
+			if m.stateCursor < 0 {
+				m.stateCursor = len(serverStates) - 1
+			}
+		case key.Matches(msg, shared.Keys.Down):
+			m.stateCursor++
+			if m.stateCursor >= len(serverStates) {
+				m.stateCursor = 0
+			}
+		case key.Matches(msg, shared.Keys.Enter):
+			state := serverStates[m.stateCursor]
+			m.submitting = true
+			m.err = ""
+			a := adminActions[m.cursor]
+			return m, m.executeAction(a, state)
+		}
+
+	case "confirm":
+		switch {
+		case key.Matches(msg, shared.Keys.Confirm), msg.String() == "y":
+			m.submitting = true
+			m.err = ""
+			a := adminActions[m.cursor]
+			return m, m.executeAction(a, "")
+		case key.Matches(msg, shared.Keys.Deny), msg.String() == "n":
+			m.promptStage = ""
+			return m, nil
+		}
+	}
+	return m, nil
+}
+
+func (m Model) enterAction() tea.Cmd {
+	a := adminActions[m.cursor]
+	switch {
+	case a.needsHost:
+		m.promptStage = "host"
+		m.hostInput.SetValue("")
+		m.hostInput.Focus()
+		m.err = ""
+		return textinput.Blink
+	case a.apiAction == "Force Delete":
+		m.promptStage = "confirm"
+		m.err = ""
+		return nil
+	case a.apiAction == "Reset State":
+		m.promptStage = "state"
+		m.stateCursor = 0
+		m.err = ""
+		return nil
+	default:
+		// Cold Migrate: execute directly
+		m.submitting = true
+		m.err = ""
+		return m.executeAction(a, "")
+	}
+}
+
+func (m Model) executeWithHost(host string) tea.Cmd {
+	a := adminActions[m.cursor]
+	return m.executeAction(a, host)
+}
+
+func (m Model) executeAction(a adminAction, arg string) tea.Cmd {
+	client := m.client
+	id := m.serverID
+	name := m.serverName
+	action := a.apiAction
+
+	return func() tea.Msg {
+		shared.Debugf("[serveradminact] executing %s on server %s", action, id)
+		var err error
+
+		switch action {
+		case "Migrate":
+			err = compute.MigrateServer(context.Background(), client, id)
+		case "Live Migrate":
+			err = compute.LiveMigrateServer(context.Background(), client, id, arg)
+		case "Evacuate":
+			_, err = compute.EvacuateServer(context.Background(), client, id, arg, false)
+		case "Force Delete":
+			err = compute.ForceDeleteServer(context.Background(), client, id)
+		case "Reset State":
+			err = compute.ResetServerState(context.Background(), client, id, arg)
+		}
+
+		if err != nil {
+			shared.Debugf("[serveradminact] %s failed: %v", action, err)
+			return actionErrMsg{action: action, name: name, err: err}
+		}
+		shared.Debugf("[serveradminact] %s succeeded for %s", action, name)
+		return actionDoneMsg{action: action, name: name}
+	}
+}
+
+// View renders the admin actions modal.
+func (m Model) View() string {
+	if !m.Active {
+		return ""
+	}
+
+	titleStyle := lipgloss.NewStyle().
+		Foreground(shared.ColorPrimary).
+		Bold(true).
+		Padding(0, 1)
+	title := titleStyle.Render(fmt.Sprintf("Admin Actions — %s", m.serverName))
+
+	var body string
+	switch m.promptStage {
+	case "":
+		body = m.renderActionList()
+	case "host":
+		body = m.renderHostPrompt()
+	case "state":
+		body = m.renderStatePrompt()
+	case "confirm":
+		body = m.renderConfirmPrompt()
+	}
+
+	if m.err != "" {
+		body += "\n\n" + lipgloss.NewStyle().
+			Foreground(shared.ColorError).
+			Render("  Error: "+m.err)
+	}
+
+	if m.submitting {
+		body += "\n\n  " + m.spinner.View() + " Executing..."
+	}
+
+	width := 60
+	if m.width < 64 {
+		width = m.width - 4
+	}
+
+	footer := lipgloss.NewStyle().
+		Foreground(shared.ColorMuted).
+		Render("  esc back • ↑↓ navigate • enter select")
+
+	return lipgloss.NewStyle().
+		Width(width).
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(shared.ColorPrimary).
+		Padding(1, 2).
+		Render(title + "\n\n" + body + "\n\n" + footer)
+}
+
+func (m Model) renderActionList() string {
+	var lines []string
+	cursorStyle := lipgloss.NewStyle().Foreground(shared.ColorHighlight).Bold(true)
+	normalStyle := lipgloss.NewStyle().Foreground(shared.ColorFg)
+	cursorMark := lipgloss.NewStyle().Foreground(shared.ColorPrimary).Bold(true).Render("▸ ")
+
+	for i, a := range adminActions {
+		prefix := "  "
+		style := normalStyle
+		if i == m.cursor {
+			prefix = cursorMark
+			style = cursorStyle
+		}
+		lines = append(lines, prefix+style.Render(a.label))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m Model) renderHostPrompt() string {
+	labelStyle := lipgloss.NewStyle().
+		Foreground(shared.ColorSecondary).
+		Bold(true)
+	hintStyle := lipgloss.NewStyle().
+		Foreground(shared.ColorMuted)
+	a := adminActions[m.cursor]
+	return labelStyle.Render(fmt.Sprintf("  %s — Target Host:", a.label)) +
+		"\n\n  " + m.hostInput.View() +
+		"\n\n  " + hintStyle.Render("enter to execute • esc to cancel")
+}
+
+func (m Model) renderStatePrompt() string {
+	var lines []string
+	cursorStyle := lipgloss.NewStyle().Foreground(shared.ColorHighlight).Bold(true)
+	normalStyle := lipgloss.NewStyle().Foreground(shared.ColorFg)
+	cursorMark := lipgloss.NewStyle().Foreground(shared.ColorPrimary).Bold(true).Render("▸ ")
+
+	labelStyle := lipgloss.NewStyle().
+		Foreground(shared.ColorSecondary).Bold(true)
+	lines = append(lines, labelStyle.Render("  Reset State — New State:")+"\n")
+
+	for i, state := range serverStates {
+		prefix := "  "
+		style := normalStyle
+		if i == m.stateCursor {
+			prefix = cursorMark
+			style = cursorStyle
+		}
+		lines = append(lines, prefix+style.Render(state))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m Model) renderConfirmPrompt() string {
+	warnStyle := lipgloss.NewStyle().
+		Foreground(shared.ColorWarning).
+		Bold(true)
+	mutedStyle := lipgloss.NewStyle().
+		Foreground(shared.ColorMuted)
+
+	return warnStyle.Render(fmt.Sprintf("  Force delete %s?", m.serverName)) +
+		"\n\n  " + mutedStyle.Render("This cannot be undone. Are you sure?") +
+		"\n\n  " + lipgloss.NewStyle().Foreground(shared.ColorFg).Render("[y] Yes  [n] No")
+}
+
+// SetSize updates dimensions.
+func (m *Model) SetSize(w, h int) {
+	m.width = w
+	m.height = h
+}

--- a/src/internal/ui/servermetadata/servermetadata.go
+++ b/src/internal/ui/servermetadata/servermetadata.go
@@ -1,0 +1,439 @@
+package servermetadata
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/spinner"
+	"charm.land/bubbles/v2/textinput"
+	"charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
+	"github.com/larkly/lazystack/internal/shared"
+)
+
+type metaOpDoneMsg struct {
+	action string
+	name   string
+}
+
+type metaOpErrMsg struct {
+	action string
+	name   string
+	err    error
+}
+
+// Model is the server metadata editor modal.
+type Model struct {
+	Active      bool
+	client      *gophercloud.ServiceClient
+	serverID    string
+	serverName  string
+	width       int
+	height      int
+	metadata    map[string]string
+	cursor      int
+	mode        string // "" = viewing, "add" = adding, "edit" = editing
+	editKey     string
+	keyInput    textinput.Model
+	valueInput  textinput.Model
+	loading     bool
+	submitting  bool
+	err         string
+	spinner     spinner.Model
+}
+
+// New creates a metadata editor modal.
+func New(client *gophercloud.ServiceClient, serverID, serverName string, existingMeta map[string]string) Model {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+
+	ki := textinput.New()
+	ki.Prompt = "Key:   "
+	ki.Placeholder = "lazystack_ssh_user"
+	ki.CharLimit = 255
+
+	vi := textinput.New()
+	vi.Prompt = "Value: "
+	vi.Placeholder = "ubuntu"
+	vi.CharLimit = 255
+
+	meta := make(map[string]string)
+	for k, v := range existingMeta {
+		meta[k] = v
+	}
+
+	return Model{
+		Active:     true,
+		client:     client,
+		serverID:   serverID,
+		serverName: serverName,
+		metadata:   meta,
+		keyInput:   ki,
+		valueInput: vi,
+		spinner:    s,
+	}
+}
+
+// Init initializes the model.
+func (m Model) Init() tea.Cmd {
+	return m.spinner.Tick
+}
+
+// sortedKeys returns sorted metadata keys.
+func (m Model) sortedKeys() []string {
+	keys := make([]string, 0, len(m.metadata))
+	for k := range m.metadata {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// Update handles messages.
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case metaOpDoneMsg:
+		m.submitting = false
+		m.Active = false
+		return m, func() tea.Msg {
+			return shared.ServerActionMsg{Action: msg.action, Name: msg.name}
+		}
+
+	case metaOpErrMsg:
+		m.submitting = false
+		m.err = fmt.Sprintf("%s %s: %v", msg.action, msg.name, msg.err)
+		return m, nil
+
+	case spinner.TickMsg:
+		if m.submitting || m.loading {
+			var cmd tea.Cmd
+			m.spinner, cmd = m.spinner.Update(msg)
+			return m, cmd
+		}
+		return m, nil
+
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	}
+	return m, nil
+}
+
+func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
+	if m.submitting {
+		return m, nil
+	}
+
+	if key.Matches(msg, shared.Keys.Back) {
+		if m.mode != "" {
+			m.mode = ""
+			m.err = ""
+			return m, nil
+		}
+		m.Active = false
+		return m, nil
+	}
+
+	keys := m.sortedKeys()
+
+	switch m.mode {
+	case "":
+		// Viewing mode
+		switch {
+		case key.Matches(msg, shared.Keys.Up):
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case key.Matches(msg, shared.Keys.Down):
+			if m.cursor < len(keys) {
+				m.cursor++
+			}
+		case msg.String() == "a":
+			// Add new metadata
+			m.mode = "add"
+			m.keyInput.SetValue("")
+			m.valueInput.SetValue("")
+			m.keyInput.Focus()
+			m.err = ""
+			return m, textinput.Blink
+		case msg.String() == "e":
+			// Edit selected
+			if m.cursor < len(keys) {
+				m.mode = "edit"
+				m.editKey = keys[m.cursor]
+				m.keyInput.SetValue(keys[m.cursor])
+				m.valueInput.SetValue(m.metadata[keys[m.cursor]])
+				m.keyInput.Focus()
+				m.err = ""
+				return m, textinput.Blink
+			}
+		case msg.String() == "d":
+			// Delete selected
+			if m.cursor < len(keys) {
+				return m, m.deleteMetadatum(keys[m.cursor])
+			}
+		}
+
+	case "add":
+		switch {
+		case key.Matches(msg, shared.Keys.Tab), key.Matches(msg, shared.Keys.Down):
+			// Switch to value input
+			if m.keyInput.Focused() {
+				m.keyInput.Blur()
+				m.valueInput.Focus()
+			} else {
+				m.valueInput.Blur()
+				m.keyInput.Focus()
+			}
+			return m, nil
+		case key.Matches(msg, shared.Keys.Enter):
+			return m, m.addMetadatum()
+		default:
+			var cmd tea.Cmd
+			if m.keyInput.Focused() {
+				m.keyInput, cmd = m.keyInput.Update(msg)
+			} else {
+				m.valueInput, cmd = m.valueInput.Update(msg)
+			}
+			return m, cmd
+		}
+
+	case "edit":
+		switch {
+		case key.Matches(msg, shared.Keys.Tab), key.Matches(msg, shared.Keys.Down):
+			if m.keyInput.Focused() {
+				m.keyInput.Blur()
+				m.valueInput.Focus()
+			} else {
+				m.valueInput.Blur()
+				m.keyInput.Focus()
+			}
+			return m, nil
+		case key.Matches(msg, shared.Keys.Enter):
+			return m, m.updateMetadatum()
+		default:
+			var cmd tea.Cmd
+			if m.keyInput.Focused() {
+				m.keyInput, cmd = m.keyInput.Update(msg)
+			} else {
+				m.valueInput, cmd = m.valueInput.Update(msg)
+			}
+			return m, cmd
+		}
+	}
+	return m, nil
+}
+
+func (m Model) addMetadatum() tea.Cmd {
+	key := strings.TrimSpace(m.keyInput.Value())
+	value := strings.TrimSpace(m.valueInput.Value())
+	if key == "" {
+		m.err = "Key is required"
+		return nil
+	}
+
+	m.submitting = true
+	m.err = ""
+	client := m.client
+	id := m.serverID
+	name := m.serverName
+
+	return func() tea.Msg {
+		shared.Debugf("[servermetadata] creating metadata %s=%s for server %s", key, value, name)
+		r := servers.CreateMetadatum(context.Background(), client, id, servers.MetadatumOpts{key: value})
+		if r.Err != nil {
+			shared.Debugf("[servermetadata] create metadata failed: %v", r.Err)
+			return metaOpErrMsg{action: "Update metadata", name: name, err: r.Err}
+		}
+		shared.Debugf("[servermetadata] created metadata for %s", name)
+		return metaOpDoneMsg{action: "Updated metadata", name: name}
+	}
+}
+
+func (m Model) updateMetadatum() tea.Cmd {
+	newKey := strings.TrimSpace(m.keyInput.Value())
+	value := strings.TrimSpace(m.valueInput.Value())
+	if newKey == "" {
+		m.err = "Key is required"
+		return nil
+	}
+
+	m.submitting = true
+	m.err = ""
+	client := m.client
+	id := m.serverID
+	name := m.serverName
+	oldKey := m.editKey
+
+	return func() tea.Msg {
+		shared.Debugf("[servermetadata] updating metadata %s=%s for server %s", newKey, value, name)
+		// CreateMetadatum handles both create and update (Nova PUT /metadata/{key})
+		if oldKey != newKey {
+			dr := servers.DeleteMetadatum(context.Background(), client, id, oldKey)
+			if dr.Err != nil {
+				shared.Debugf("[servermetadata] delete old key failed: %v", dr.Err)
+			}
+		}
+		cr := servers.CreateMetadatum(context.Background(), client, id, servers.MetadatumOpts{newKey: value})
+		if cr.Err != nil {
+			shared.Debugf("[servermetadata] update metadata failed: %v", cr.Err)
+			return metaOpErrMsg{action: "Update metadata", name: name, err: cr.Err}
+		}
+		shared.Debugf("[servermetadata] updated metadata for %s", name)
+		return metaOpDoneMsg{action: "Updated metadata", name: name}
+	}
+}
+
+func (m Model) deleteMetadatum(key string) tea.Cmd {
+	m.submitting = true
+	m.err = ""
+	client := m.client
+	id := m.serverID
+	name := m.serverName
+
+	return func() tea.Msg {
+		shared.Debugf("[servermetadata] deleting metadata %s from server %s", key, name)
+		r := servers.DeleteMetadatum(context.Background(), client, id, key)
+		if r.Err != nil {
+			shared.Debugf("[servermetadata] delete metadata failed: %v", r.Err)
+			return metaOpErrMsg{action: "Delete metadata", name: name, err: r.Err}
+		}
+		shared.Debugf("[servermetadata] deleted metadata from %s", name)
+		return metaOpDoneMsg{action: "Updated metadata", name: name}
+	}
+}
+
+// View renders the metadata editor.
+func (m Model) View() string {
+	if !m.Active {
+		return ""
+	}
+
+	titleStyle := lipgloss.NewStyle().
+		Foreground(shared.ColorPrimary).
+		Bold(true).
+		Padding(0, 1)
+	title := titleStyle.Render(fmt.Sprintf("Metadata — %s", m.serverName))
+
+	var body string
+	switch m.mode {
+	case "":
+		body = m.renderMetadataList()
+	case "add":
+		body = m.renderAddForm("Add")
+	case "edit":
+		body = m.renderAddForm("Edit")
+	}
+
+	if m.err != "" {
+		body += "\n\n" + lipgloss.NewStyle().
+			Foreground(shared.ColorError).
+			Render("  Error: "+m.err)
+	}
+
+	if m.submitting {
+		body += "\n\n  " + m.spinner.View() + " Saving..."
+	}
+
+	width := 60
+	if m.width < 64 {
+		width = m.width - 4
+	}
+
+	footer := lipgloss.NewStyle().
+		Foreground(shared.ColorMuted).
+		Render("  a add • e edit • d delete • ↑↓ navigate • esc back")
+
+	return lipgloss.NewStyle().
+		Width(width).
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(shared.ColorPrimary).
+		Padding(1, 2).
+		Render(title + "\n\n" + body + "\n\n" + footer)
+}
+
+func (m Model) renderMetadataList() string {
+	keys := m.sortedKeys()
+
+	if len(keys) == 0 {
+		return lipgloss.NewStyle().
+			Foreground(shared.ColorMuted).
+			Render("  No metadata set.\n\n  Press 'a' to add a key-value pair.")
+	}
+
+	keyStyle := lipgloss.NewStyle().
+		Foreground(shared.ColorSecondary).
+		Bold(true).
+		Width(28)
+	valueStyle := lipgloss.NewStyle().Foreground(shared.ColorFg)
+	cursorMark := lipgloss.NewStyle().Foreground(shared.ColorPrimary).Bold(true).Render("▸ ")
+
+	var lines []string
+	for i, k := range keys {
+		prefix := "  "
+		kStyle := keyStyle
+		vStyle := valueStyle
+		if i == m.cursor {
+			prefix = cursorMark
+			kStyle = keyStyle.Copy().Foreground(shared.ColorHighlight).Bold(true)
+			vStyle = valueStyle.Copy().Foreground(shared.ColorHighlight).Bold(true)
+		}
+		val := m.metadata[k]
+		if len(val) > 30 {
+			val = val[:29] + "…"
+		}
+		lines = append(lines, prefix+kStyle.Render(k)+vStyle.Render(val))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m Model) renderAddForm(mode string) string {
+	labelStyle := lipgloss.NewStyle().
+		Foreground(shared.ColorSecondary).
+		Bold(true)
+
+	focusedBorder := lipgloss.NewStyle().BorderForeground(shared.ColorPrimary)
+	blurredBorder := lipgloss.NewStyle().BorderForeground(shared.ColorMuted)
+
+	keyBox := focusedBorder
+	valBox := blurredBorder
+	if !m.keyInput.Focused() {
+		keyBox = blurredBorder
+		valBox = focusedBorder
+	}
+
+	keySection := lipgloss.JoinVertical(lipgloss.Left,
+		labelStyle.Render("  Key:"),
+		keyBox.Border(lipgloss.RoundedBorder()).Padding(0, 1).Render(m.keyInput.View()),
+	)
+	valSection := lipgloss.JoinVertical(lipgloss.Left,
+		labelStyle.Render("  Value:"),
+		valBox.Border(lipgloss.RoundedBorder()).Padding(0, 1).Render(m.valueInput.View()),
+	)
+
+	hintStyle := lipgloss.NewStyle().Foreground(shared.ColorMuted)
+	return lipgloss.JoinVertical(lipgloss.Left,
+		labelStyle.Render(fmt.Sprintf("  %s Metadata", mode)),
+		"",
+		keySection,
+		"",
+		valSection,
+		"",
+		hintStyle.Render("  enter save • tab switch • esc cancel"),
+	)
+}
+
+// SetSize updates dimensions.
+func (m *Model) SetSize(w, h int) {
+	m.width = w
+	m.height = h
+}


### PR DESCRIPTION
- Add serveradminact UI: Cold Migrate, Live Migrate, Evacuate, Force Delete, Reset State
  via Gophercloud compute API. Press 'A' from server detail.
- Add servermetadata UI: View/add/edit/delete server metadata key-value pairs.
  Press 'M' from server detail.
- Fix EvacuateOpts to use non-pointer Host/OnSharedStorage (matching Gophercloud v2 API)
- Wire into app modal system, keymap, and view renderer
- Add 'A' (admin actions) and 'M' (metadata) key bindings
