### PR TITLE
feat: add bulk multi-select for volumes and images

### DIFF
--- a/src/internal/app/actions_image.go
+++ b/src/internal/app/actions_image.go
@@ -61,6 +61,34 @@ func (m Model) openImageDeleteConfirm() (Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m Model) openImagesDeleteConfirm() (Model, tea.Cmd) {
+	imgs := m.imageView.SelectedImages()
+	if len(imgs) == 0 {
+		return m, nil
+	}
+	for _, im := range imgs {
+		if im.Protected {
+			m.statusBar.StickyHint = "One or more selected images are protected"
+			return m, nil
+		}
+	}
+	refs := make([]modal.ServerRef, len(imgs))
+	for i, im := range imgs {
+		name := im.Name
+		if name == "" {
+			name = im.ID
+		}
+		refs[i] = modal.ServerRef{ID: im.ID, Name: name}
+	}
+	m.imageView.ClearSelection()
+	m.confirm = modal.NewBulkConfirm("delete_images_bulk", refs)
+	m.confirm.Title = "Delete Images"
+	m.confirm.Body = fmt.Sprintf("Delete %d selected images?", len(refs))
+	m.confirm.SetSize(m.width, m.height)
+	m.activeModal = modalConfirm
+	return m, nil
+}
+
 func (m Model) openImageDeactivateConfirm() (Model, tea.Cmd) {
 	im := m.imageView.SelectedImage()
 	if im == nil {

--- a/src/internal/app/actions_resource.go
+++ b/src/internal/app/actions_resource.go
@@ -79,6 +79,56 @@ func (m Model) openVolumeDeleteConfirm() (Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m Model) openVolumesDeleteConfirm() (Model, tea.Cmd) {
+	vols := m.volumeList.SelectedVolumes()
+	if len(vols) == 0 {
+		return m, nil
+	}
+	refs := make([]modal.ServerRef, len(vols))
+	for i, v := range vols {
+		name := v.Name
+		if name == "" {
+			name = v.ID
+		}
+		refs[i] = modal.ServerRef{ID: v.ID, Name: name}
+	}
+	m.volumeList.ClearSelection()
+	m.confirm = modal.NewBulkConfirm("delete_volumes_bulk", refs)
+	m.confirm.Title = "Delete Volumes"
+	m.confirm.Body = fmt.Sprintf("Delete %d selected volumes?", len(refs))
+	m.confirm.SetSize(m.width, m.height)
+	m.activeModal = modalConfirm
+	return m, nil
+}
+
+func (m Model) openVolumesDetachConfirm() (Model, tea.Cmd) {
+	vols := m.volumeList.SelectedVolumes()
+	if len(vols) == 0 {
+		return m, nil
+	}
+	var refs []modal.ServerRef
+	for _, v := range vols {
+		if v.AttachedServerID != "" || len(v.Attachments) > 0 {
+			name := v.Name
+			if name == "" {
+				name = v.ID
+			}
+			refs = append(refs, modal.ServerRef{ID: v.ID, Name: name})
+		}
+	}
+	if len(refs) == 0 {
+		m.statusBar.StickyHint = "None of the selected volumes are attached"
+		return m, nil
+	}
+	m.volumeList.ClearSelection()
+	m.confirm = modal.NewBulkConfirm("detach_volumes_bulk", refs)
+	m.confirm.Title = "Detach Volumes"
+	m.confirm.Body = fmt.Sprintf("Detach %d selected volumes?", len(refs))
+	m.confirm.SetSize(m.width, m.height)
+	m.activeModal = modalConfirm
+	return m, nil
+}
+
 // blockStorageAvailable reports whether the connected cloud exposes a
 // Cinder (block storage) endpoint. Volume attach/detach/create/delete flows
 // depend on this client being non-nil; callers must gate on this before

--- a/src/internal/app/actions_server.go
+++ b/src/internal/app/actions_server.go
@@ -590,7 +590,17 @@ func (m Model) getSelectedServerInfo() (id, name string) {
 func (m Model) executeAction(action modal.ConfirmAction) (Model, tea.Cmd) {
 	client := m.client.Compute
 
-	// Bulk actions
+	// Resource-specific bulk actions (must come before the generic server bulk guard)
+	switch action.Action {
+	case "delete_volumes_bulk":
+		return m, m.executeDeleteVolumesBulk(action.Servers)
+	case "detach_volumes_bulk":
+		return m, m.executeDetachVolumesBulk(action.Servers)
+	case "delete_images_bulk":
+		return m, m.executeDeleteImagesBulk(action.Servers)
+	}
+
+	// Bulk actions (server-only)
 	if len(action.Servers) > 0 {
 		m.serverList.ClearSelection()
 		return m, m.executeBulkAction(client, action)
@@ -1364,4 +1374,100 @@ func (m Model) openServerMetadata() (Model, tea.Cmd) {
 	m.serverMetadata = servermetadata.New(m.client.Compute, id, name, meta)
 	m.serverMetadata.SetSize(m.width, m.height)
 	return m, m.serverMetadata.Init()
+}
+
+func (m Model) executeDeleteVolumesBulk(refs []modal.ServerRef) tea.Cmd {
+	bsClient := m.client.BlockStorage
+	if bsClient == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		var errs []string
+		for _, ref := range refs {
+			shared.Debugf("[action] deleting volume %s", ref.Name)
+			if err := volume.DeleteVolume(context.Background(), bsClient, ref.ID); err != nil {
+				shared.Debugf("[action] delete volume %s failed: %s", ref.Name, err)
+				errs = append(errs, fmt.Sprintf("%s: %v", ref.Name, err))
+			}
+		}
+		if len(errs) > 0 {
+			return shared.ResourceActionErrMsg{
+				Action: "Delete volumes",
+				Name:   fmt.Sprintf("%d volumes", len(refs)),
+				Err:    fmt.Errorf("%s", strings.Join(errs, "; ")),
+			}
+		}
+		return shared.ResourceActionMsg{
+			Action: "Deleted volumes",
+			Name:   fmt.Sprintf("%d volumes", len(refs)),
+		}
+	}
+}
+
+func (m Model) executeDetachVolumesBulk(refs []modal.ServerRef) tea.Cmd {
+	computeC := m.client.Compute
+	bsClient := m.client.BlockStorage
+	if bsClient == nil || computeC == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		var errs []string
+		for _, ref := range refs {
+			shared.Debugf("[action] detaching volume %s", ref.Name)
+			vol, err := volume.GetVolume(context.Background(), bsClient, ref.ID)
+			if err != nil {
+				shared.Debugf("[action] detach volume %s failed: %s", ref.Name, err)
+				errs = append(errs, fmt.Sprintf("%s: %v", ref.Name, err))
+				continue
+			}
+			if !vol.IsAttached() {
+				continue
+			}
+			for _, att := range vol.Attachments {
+				if err := volume.DetachVolume(context.Background(), computeC, att.ServerID, ref.ID); err != nil {
+					shared.Debugf("[action] detach volume %s from server %s failed: %s", ref.Name, att.ServerID, err)
+					errs = append(errs, fmt.Sprintf("%s from %s: %v", ref.Name, att.ServerID, err))
+				}
+			}
+		}
+		if len(errs) > 0 {
+			return shared.ResourceActionErrMsg{
+				Action: "Detach volumes",
+				Name:   fmt.Sprintf("%d volumes", len(refs)),
+				Err:    fmt.Errorf("%s", strings.Join(errs, "; ")),
+			}
+		}
+		return shared.ResourceActionMsg{
+			Action: "Detached volumes",
+			Name:   fmt.Sprintf("%d volumes", len(refs)),
+		}
+	}
+}
+
+func (m Model) executeDeleteImagesBulk(refs []modal.ServerRef) tea.Cmd {
+	imgClient := m.client.Image
+	if imgClient == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		var errs []string
+		for _, ref := range refs {
+			shared.Debugf("[action] deleting image %s", ref.Name)
+			if err := image.DeleteImage(context.Background(), imgClient, ref.ID); err != nil {
+				shared.Debugf("[action] delete image %s failed: %s", ref.Name, err)
+				errs = append(errs, fmt.Sprintf("%s: %v", ref.Name, err))
+			}
+		}
+		if len(errs) > 0 {
+			return shared.ResourceActionErrMsg{
+				Action: "Delete images",
+				Name:   fmt.Sprintf("%d images", len(refs)),
+				Err:    fmt.Errorf("%s", strings.Join(errs, "; ")),
+			}
+		}
+		return shared.ResourceActionMsg{
+			Action: "Deleted images",
+			Name:   fmt.Sprintf("%d images", len(refs)),
+		}
+	}
 }

--- a/src/internal/app/app.go
+++ b/src/internal/app/app.go
@@ -388,6 +388,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		if m.view != viewServerCreate && m.view != viewVolumeCreate && m.view != viewKeypairCreate {
+			// Volume list: esc clears selection when items are selected
+			if m.view == viewVolumeList && m.volumeList.SelectionCount() > 0 && (key.Matches(msg, shared.Keys.Back) || msg.String() == "esc") {
+				m.volumeList.ClearSelection()
+				return m, nil
+			}
+			// Image view: esc clears selection when items are selected
+			if m.view == viewImageView && m.imageView.SelectionCount() > 0 && (key.Matches(msg, shared.Keys.Back) || msg.String() == "esc") {
+				m.imageView.ClearSelection()
+				return m, nil
+			}
 			// Server list filter mode: esc should clear filter before global back-nav/tab handlers.
 			if m.view == viewServerList && m.serverList.IsFiltering() && (key.Matches(msg, shared.Keys.Back) || msg.String() == "esc") {
 				return m.updateActiveView(msg)
@@ -598,6 +608,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m.openVolumeDetail()
 			}
 			if key.Matches(msg, shared.Keys.Delete) {
+				if m.volumeList.SelectionCount() > 0 {
+					return m.openVolumesDeleteConfirm()
+				}
 				return m.openVolumeDeleteConfirm()
 			}
 			if key.Matches(msg, shared.Keys.Create) {
@@ -607,6 +620,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m.openVolumeAttach()
 			}
 			if key.Matches(msg, shared.Keys.Detach) {
+				if m.volumeList.SelectionCount() > 0 {
+					return m.openVolumesDetachConfirm()
+				}
 				return m.openVolumeDetach()
 			}
 		}
@@ -862,6 +878,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			pane := m.imageView.FocusedPane()
 
 			if key.Matches(msg, shared.Keys.Delete) {
+				if m.imageView.SelectionCount() > 0 {
+					return m.openImagesDeleteConfirm()
+				}
 				return m.openImageDeleteConfirm()
 			}
 			if key.Matches(msg, shared.Keys.Deactivate) && (pane == imageview.FocusSelector || pane == imageview.FocusInfo) {

--- a/src/internal/ui/imageview/imageview.go
+++ b/src/internal/ui/imageview/imageview.go
@@ -173,6 +173,7 @@ type Model struct {
 	spinner         spinner.Model
 	err             string
 	refreshInterval time.Duration
+	selected        map[string]bool // selected image IDs for bulk actions
 }
 
 // New creates an image view model.
@@ -192,6 +193,7 @@ func New(imageClient, computeClient *gophercloud.ServiceClient, refreshInterval 
 		spinner:         s,
 		searchInput:     ti,
 		refreshInterval: refreshInterval,
+		selected:        make(map[string]bool),
 		sortAsc:         true,
 	}
 }
@@ -216,6 +218,34 @@ func (m Model) SelectedImage() *img.Image {
 		return &i
 	}
 	return nil
+}
+
+// SelectedImages returns all selected images, or the cursor image if none selected.
+func (m Model) SelectedImages() []img.Image {
+	visible := m.visibleImages()
+	if len(m.selected) > 0 {
+		var result []img.Image
+		for _, im := range visible {
+			if m.selected[im.ID] {
+				result = append(result, im)
+			}
+		}
+		return result
+	}
+	if i := m.SelectedImage(); i != nil {
+		return []img.Image{*i}
+	}
+	return nil
+}
+
+// SelectionCount returns the number of selected images.
+func (m Model) SelectionCount() int {
+	return len(m.selected)
+}
+
+// ClearSelection clears all selected images.
+func (m *Model) ClearSelection() {
+	m.selected = make(map[string]bool)
 }
 
 // ImageID returns the selected image ID.
@@ -354,14 +384,20 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 			m.selectorScroll = 0
 			return m, nil
 		}
+		if len(m.selected) > 0 {
+			m.ClearSelection()
+			return m, nil
+		}
 		return m, nil
 
 	case key.Matches(msg, shared.Keys.Tab):
 		m.focus = (m.focus + 1) % focusPaneCount
+		m.ClearSelection()
 		return m, nil
 
 	case key.Matches(msg, shared.Keys.ShiftTab):
 		m.focus = (m.focus + focusPaneCount - 1) % focusPaneCount
+		m.ClearSelection()
 		return m, nil
 
 	case key.Matches(msg, shared.Keys.Up):
@@ -392,6 +428,23 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 			m.searchInput.SetValue(m.searchFilter)
 			m.searchInput.Focus()
 			return m, m.searchInput.Focus()
+		}
+	case key.Matches(msg, shared.Keys.Select):
+		if m.focus == FocusSelector {
+			im := m.SelectedImage()
+			if im != nil {
+				if m.selected[im.ID] {
+					delete(m.selected, im.ID)
+				} else {
+					m.selected[im.ID] = true
+				}
+				visible := m.visibleImages()
+				if m.cursor < len(visible)-1 {
+					m.cursor++
+					m.ensureSelectorCursorVisible()
+				}
+			}
+			return m, nil
 		}
 	}
 	return m, nil
@@ -937,6 +990,7 @@ func (m Model) renderSelectorContent(maxWidth, maxHeight int) string {
 
 		selected := m.focus == FocusSelector && i == m.cursor
 		isCursor := i == m.cursor
+		isBulkSelected := m.selected[im.ID]
 
 		name := im.Name
 		if name == "" && len(im.ID) > 8 {
@@ -958,6 +1012,9 @@ func (m Model) renderSelectorContent(maxWidth, maxHeight int) string {
 		if selected {
 			rowBg = lipgloss.Color("#073642")
 			hasBg = true
+		} else if isBulkSelected {
+			rowBg = lipgloss.Color("#1a1a2e")
+			hasBg = true
 		}
 
 		var parts []string
@@ -975,6 +1032,9 @@ func (m Model) renderSelectorContent(maxWidth, maxHeight int) string {
 			if col.Key == "status" {
 				style = imageStatusStyle(im.Status).Width(w)
 			}
+			if isBulkSelected {
+				style = style.Foreground(shared.ColorPrimary)
+			}
 			if isCursor {
 				style = style.Bold(true)
 			}
@@ -985,11 +1045,17 @@ func (m Model) renderSelectorContent(maxWidth, maxHeight int) string {
 		}
 
 		prefix := "  "
+		if isBulkSelected {
+			prefix = "\u25cf "
+		}
 		prefixStyle := lipgloss.NewStyle()
 		gapStyle := lipgloss.NewStyle()
 		if hasBg {
 			prefixStyle = prefixStyle.Background(rowBg)
 			gapStyle = gapStyle.Background(rowBg)
+		}
+		if isBulkSelected {
+			prefixStyle = prefixStyle.Foreground(shared.ColorPrimary)
 		}
 
 		gap := gapStyle.Render(" ")
@@ -1420,6 +1486,9 @@ func (m *Model) SetSize(w, h int) {
 func (m Model) Hints() string {
 	switch m.focus {
 	case FocusSelector:
+		if len(m.selected) > 0 {
+			return fmt.Sprintf("(%d selected) space toggle • ^d delete • esc clear • ? help", len(m.selected))
+		}
 		return "\u2191\u2193 navigate \u2022 / search \u2022 S sort \u2022 ^n upload \u2022 d deactivate \u2022 ^d delete \u2022 tab switch pane \u2022 R refresh \u2022 ? help"
 	case FocusInfo:
 		return "enter edit \u2022 ^d delete \u2022 tab switch pane \u2022 R refresh \u2022 ? help"

--- a/src/internal/ui/volumelist/volumelist.go
+++ b/src/internal/ui/volumelist/volumelist.go
@@ -142,6 +142,7 @@ type Model struct {
 	sortHighlight   bool
 	sortClearAt     time.Time
 	highlight       map[string]bool // volume IDs to highlight (from cross-resource navigation)
+	selected        map[string]bool // selected volume IDs for bulk actions
 }
 
 // New creates a volume list model.
@@ -156,6 +157,7 @@ func New(client, computeClient *gophercloud.ServiceClient, refreshInterval time.
 		spinner:         s,
 		refreshInterval: refreshInterval,
 		serverNames:     make(map[string]string),
+		selected:        make(map[string]bool),
 		sortAsc:         true,
 	}
 }
@@ -173,6 +175,33 @@ func (m Model) SelectedVolume() *volume.Volume {
 		return &v
 	}
 	return nil
+}
+
+// SelectedVolumes returns all selected volumes, or the cursor volume if none selected.
+func (m Model) SelectedVolumes() []volume.Volume {
+	if len(m.selected) > 0 {
+		var result []volume.Volume
+		for _, v := range m.volumes {
+			if m.selected[v.ID] {
+				result = append(result, v)
+			}
+		}
+		return result
+	}
+	if v := m.SelectedVolume(); v != nil {
+		return []volume.Volume{*v}
+	}
+	return nil
+}
+
+// SelectionCount returns the number of selected volumes.
+func (m Model) SelectionCount() int {
+	return len(m.selected)
+}
+
+// ClearSelection clears all selected volumes.
+func (m *Model) ClearSelection() {
+	m.selected = make(map[string]bool)
 }
 
 // CopyEntries returns the title and copyable fields for the selected volume.
@@ -328,6 +357,18 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				m.cursor = 0
 			}
 			m.ensureVisible()
+		case key.Matches(msg, shared.Keys.Select):
+			if v := m.SelectedVolume(); v != nil {
+				if m.selected[v.ID] {
+					delete(m.selected, v.ID)
+				} else {
+					m.selected[v.ID] = true
+				}
+				if m.cursor < len(m.volumes)-1 {
+					m.cursor++
+					m.ensureVisible()
+				}
+			}
 		}
 	}
 	return m, nil
@@ -511,7 +552,8 @@ func (m Model) View() string {
 			"bootable": v.Bootable,
 		}
 
-		row := m.renderDataRow(values, v.Status, cursor)
+		isSelected := m.selected[v.ID]
+		row := m.renderDataRow(values, v.Status, cursor, isSelected)
 		b.WriteString(row + "\n")
 	}
 
@@ -529,11 +571,14 @@ func (m Model) renderRow(render func(Column) string) string {
 	return "  " + strings.Join(parts, " ")
 }
 
-func (m Model) renderDataRow(values map[string]string, status string, cursor bool) string {
+func (m Model) renderDataRow(values map[string]string, status string, cursor bool, selected bool) string {
 	var rowBg color.Color
 	hasBg := false
 	if cursor {
 		rowBg = lipgloss.Color("#073642")
+		hasBg = true
+	} else if selected {
+		rowBg = lipgloss.Color("#1a1a2e")
 		hasBg = true
 	}
 
@@ -552,6 +597,9 @@ func (m Model) renderDataRow(values map[string]string, status string, cursor boo
 		if col.Key == "status" {
 			style = volumeStatusStyle(status).Width(w)
 		}
+		if selected {
+			style = style.Foreground(shared.ColorPrimary)
+		}
 		if cursor {
 			style = style.Bold(true)
 		}
@@ -563,11 +611,17 @@ func (m Model) renderDataRow(values map[string]string, status string, cursor boo
 	}
 
 	prefix := "  "
+	if selected {
+		prefix = "\u25cf "
+	}
 	prefixStyle := lipgloss.NewStyle()
 	gapStyle := lipgloss.NewStyle()
 	if hasBg {
 		prefixStyle = prefixStyle.Background(rowBg)
 		gapStyle = gapStyle.Background(rowBg)
+	}
+	if selected {
+		prefixStyle = prefixStyle.Foreground(shared.ColorPrimary)
 	}
 
 	gap := gapStyle.Render(" ")
@@ -686,5 +740,8 @@ func (m *Model) applyHighlight() {
 
 // Hints returns key hints.
 func (m Model) Hints() string {
-	return "↑↓ navigate • enter detail • ^n create • ^d delete • ^a attach • ^t detach • R refresh • 1-5/←→ switch tab • ? help"
+	if len(m.selected) > 0 {
+		return fmt.Sprintf("(%d selected) space toggle • ^d delete • ^t detach • esc clear • ? help", len(m.selected))
+	}
+	return "↑↓ navigate • space select • enter detail • ^n create • ^d delete • ^a attach • ^t detach • R refresh • 1-5/←→ switch tab • ? help"
 }


### PR DESCRIPTION
Adds SPACE-based bulk selection to the volume list and image selector pane, matching the existing server-list pattern.

### Volume List
- **SPACE** toggles selection under cursor (auto-advances for rapid multi-select)
- Selected rows show `●` prefix with `#1a1a2e` background and `ColorPrimary` foreground
- Hints switch to bulk-aware wording when items are selected
- **Ctrl+d** opens bulk delete confirmation (`delete_volumes_bulk`)
- **Ctrl+t** opens bulk detach confirmation (`detach_volumes_bulk`) — filters to attached volumes only
- **ESC** clears selection first, then navigates back

### Image View
- **SPACE** toggles selection only when `FocusSelector` is active
- Same visual markers and accessors as volume list
- **Ctrl+d** opens bulk delete confirmation (`delete_images_bulk`)
- **Protected images are pre-checked** — if any selected image is protected, aborts with sticky hint before opening modal
- Selection **clears on pane switch** (Tab/Shift+Tab) to avoid stale state confusion

### Bug Fix
Fixed a routing bug where `executeAction()`'s generic server bulk guard (`if len(action.Servers) > 0`) was swallowing volume/image bulk actions and routing them to the compute-server-only `executeBulkAction()`. Resource-specific bulk cases now dispatch **before** the generic guard.

### Files Changed
- `src/internal/ui/volumelist/volumelist.go`
- `src/internal/ui/imageview/imageview.go`
- `src/internal/app/app.go`
- `src/internal/app/actions_resource.go`
- `src/internal/app/actions_image.go`
- `src/internal/app/actions_server.go`

### Testing
- `go build ./...` ✅ (from `src/`)
- `go test ./...` ✅ (from `src/`)
- Manual: select multiple volumes → delete → volumes actually deleted (verified after routing fix)
