### PR TITLE
ci: bump actions/upload-artifact from v4 to v7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         run: make test
         
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: src/coverage.out


### PR DESCRIPTION
## Problem

`actions/upload-artifact@v4` in test.yml is outdated — the rest of the repo uses v7 (release.yml). v4 is deprecated by GitHub Actions.

## Fix

Bump to v7 to align with release.yml.