### PR TITLE
ci: remove stale actions/checkout ignore rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,3 @@ updates:
     schedule:
       interval: "weekly"
 
-    ignore:
-      - dependency-name: "actions/checkout"
-        versions: [">=7"]


### PR DESCRIPTION
The actions/checkout v7 ESM breakage that prompted this ignore rule has been resolved. All repos are running v7 successfully. Removing the stale ignore so Dependabot can create future checkout version bump PRs.