### PR TITLE
Fix Nova microversion negotiation (always falls back to 2.100, breaks pre-2.100 clouds)

### DIFF
--- a/src/internal/cloud/client.go
+++ b/src/internal/cloud/client.go
@@ -48,7 +48,7 @@ func negotiateNovaMicroversion(ctx context.Context, compute *gophercloud.Service
 	// Version discovery returns the API versions supported by the deployment.
 	url := compute.ServiceURL("")
 	resp, err := compute.Get(ctx, url, nil, &gophercloud.RequestOpts{
-		// Version discovery does not need a microversion
+		KeepResponseBody: true,
 	})
 	if err != nil {
 		shared.Debugf("[cloud] negotiateMicroversion: version discovery failed: %v, falling back to %s", err, ceiling)
@@ -82,6 +82,9 @@ func negotiateNovaMicroversion(ctx context.Context, compute *gophercloud.Service
 			maxVersion = v.Version
 			break
 		}
+	}
+	if (maxVersion == "" || maxVersion == "unknown") && versionDoc.Version.Version != "" {
+		maxVersion = versionDoc.Version.Version
 	}
 
 	// If we couldn't parse it, fall back


### PR DESCRIPTION
## Problem

`negotiateNovaMicroversion` always falls back to the hardcoded ceiling `2.100`, so every compute request is sent with `OpenStack-API-Version: compute 2.100`. Any Nova whose `max_version` is below 2.100 rejects all compute calls with **406**:

```
listing servers: ... got 406 instead:
{"computeFault": {"code": 406, "message": "Version 2.100 is not supported by the API. Minimum is 2.1 and maximum is 2.88."}}
```

## Root cause

Two bugs in the version-discovery path:

1. **Response body already closed.** The discovery `GET` is issued without `KeepResponseBody`, so gophercloud drains and closes the body before the manual `json.NewDecoder(resp.Body).Decode(...)` runs. Decoding always fails with `http: read on closed response body`, and the code falls back to the ceiling. Negotiation *never* succeeds, on any cloud.
2. **Singular version document not parsed.** The queried endpoint is the versioned base (`.../v2.1/`), which returns a single `version` object, not the `versions` array. The parser only reads `versionDoc.Versions`, so even with the body available `maxVersion` stays `unknown`.

## Fix

- Pass `KeepResponseBody: true` to the discovery request so the body can be decoded.
- Fall back to the singular `version` object when the `versions` array is absent.

With both, negotiation resolves the real max (e.g. 2.88) and caps correctly.

## Testing

Built and run against an OpenStack deployment whose Nova max microversion is 2.88. Before: every compute view 406s. After (`--debug`): `nova_version=2.88 (max=2.88)` and server/volume/network lists load.